### PR TITLE
Add Dockerfile and Makefile, to allow for simple containerized execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use an official Python image as the base
+FROM python:3.12-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the project files into the container
+COPY . /app
+
+# Install Python dependencies
+RUN pip install --root-user-action=ignore -e .
+
+# Expose the project directory as a volume
+VOLUME ["/app"]
+
+# Set the entry point to the openevolve-run.py script
+ENTRYPOINT ["python", "/app/openevolve-run.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Variables
+PROJECT_DIR := $(shell pwd)
+DOCKER_IMAGE := openevolve
+VENV_DIR := $(PROJECT_DIR)/env
+PYTHON := $(VENV_DIR)/bin/python
+PIP := $(VENV_DIR)/bin/pip
+
+# Default target
+.PHONY: all
+all: install test
+
+# Create and activate the virtual environment
+.PHONY: venv
+venv:
+	python3 -m venv $(VENV_DIR)
+
+# Install Python dependencies in the virtual environment
+.PHONY: install
+install: venv
+	$(PIP) install -e .
+
+# Run Black code formatting
+.PHONY: lint
+lint: venv
+	$(PYTHON) -m black openevolve examples tests
+
+# Run tests using the virtual environment
+.PHONY: test
+test: venv
+	$(PYTHON) -m unittest discover -s tests -p "test_*.py"
+
+# Build the Docker image
+.PHONY: docker-build
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .
+
+# Run the Docker container with the example
+.PHONY: docker-run
+docker-run:
+	docker run --rm -v $(PROJECT_DIR):/app $(DOCKER_IMAGE) examples/function_minimization/initial_program.py examples/function_minimization/evaluator.py --config examples/function_minimization/config.yaml --iterations 1000

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ OpenEvolve follows an evolutionary approach with the following components:
 
 ### Installation
 
+To install natively, use:
 ```bash
 git clone https://github.com/codelion/openevolve.git
 cd openevolve
@@ -58,6 +59,14 @@ OpenEvolve can also be run from the command line:
 
 ```bash
 python openevolve-run.py path/to/initial_program.py path/to/evaluator.py --config path/to/config.yaml --iterations 1000
+```
+
+### Docker
+
+You can also install and execute via Docker:
+```bash
+docker build -t openevolve .
+docker run --rm -v .:/app openevolve examples/function_minimization/initial_program.py examples/function_minimization/evaluator.py --config examples/function_minimization/config.yaml --iterations 1000
 ```
 
 ## Configuration


### PR DESCRIPTION
With the Dockerfile, the agent can be executed in a container via
```
docker build -t openevolve .
docker run --rm -v .:/app openevolve examples/function_minimization/initial_program.py examples/function_minimization/evaluator.py --config examples/function_minimization/config.yaml --iterations 1000
```
or shorter with the Makefile:
```
make docker-build
make docker-run
```

The Makefile also allows to do
```
make test
make lint
```