### PR TITLE
Add iteration_found field to track when best program was discovered

### DIFF
--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -149,6 +149,7 @@ class OpenEvolve:
             code=self.initial_program_code,
             language=self.language,
             metrics=initial_metrics,
+            iteration_found=start_iteration
         )
 
         self.database.add(initial_program)
@@ -235,7 +236,7 @@ class OpenEvolve:
                 )
 
                 # Add to database
-                self.database.add(child_program)
+                self.database.add(child_program, iteration=i+1)
 
                 # Log progress
                 iteration_time = time.time() - iteration_start
@@ -380,6 +381,7 @@ class OpenEvolve:
                     {
                         "id": best_program.id,
                         "generation": best_program.generation,
+                        "iteration_found": best_program.iteration_found,
                         "iteration": iteration,
                         "metrics": best_program.metrics,
                         "language": best_program.language,
@@ -435,6 +437,7 @@ class OpenEvolve:
                 {
                     "id": program.id,
                     "generation": program.generation,
+                    "iteration_found": program.iteration_found,
                     "timestamp": program.timestamp,
                     "parent_id": program.parent_id,
                     "metrics": program.metrics,

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -32,6 +32,7 @@ class Program:
     parent_id: Optional[str] = None
     generation: int = 0
     timestamp: float = field(default_factory=time.time)
+    iteration_found: int = 0  # Track which iteration this program was found
 
     # Performance metrics
     metrics: Dict[str, float] = field(default_factory=dict)
@@ -90,17 +91,24 @@ class ProgramDatabase:
 
         logger.info(f"Initialized program database with {len(self.programs)} programs")
 
-    def add(self, program: Program) -> str:
+    def add(self, program: Program, iteration: int = None) -> str:
         """
         Add a program to the database
 
         Args:
             program: Program to add
+            iteration: Current iteration (defaults to last_iteration)
 
         Returns:
             Program ID
         """
         # Store the program
+        # If iteration is provided, update the program's iteration_found
+        if iteration is not None:
+            program.iteration_found = iteration
+            # Update last_iteration if needed
+            self.last_iteration = max(self.last_iteration, iteration)
+            
         self.programs[program.id] = program
 
         # Calculate feature coordinates for MAP-Elites


### PR DESCRIPTION
Currently, the best_program_info.json file contains the current iteration number, not the iteration when the best program was actually discovered. This makes it difficult to analyze how quickly the algorithm finds better solutions.
When monitoring the progress using a command like:
`watch -n 10 'jq ".metrics.combined_score, .iteration" "$(ls -d checkpoint_* | sort -V | tail -n1)/best_program_info.json"'`
The iteration value shown is the checkpoint iteration, not when the best program was actually found.
Solution
Added iteration_found field to the Program class to track when a program was discovered during evolution
Updated the add method in ProgramDatabase to set this field when adding a new program
Modified the _save_checkpoint and _save_best_program methods to include the iteration_found field in the output JSON files
Updated initialization of the initial program to set its iteration_found value
Testing
Tested with the function_minimization example to confirm the field is correctly saved in best_program_info.json. The monitoring command can now be updated to:
`watch -n 10 'jq ".metrics.combined_score, .iteration_found, .iteration" "$(ls -d checkpoint_* | sort -V | tail -n1)/best_program_info.json"'`
This now correctly shows:
1. The best program's score
The iteration when that best program was found
The current iteration (checkpoint iteration)