### PR TITLE
Fix: resolve parameter error when using o3 models with official OpenAI API

### DIFF
--- a/openevolve/llm/openai.py
+++ b/openevolve/llm/openai.py
@@ -51,12 +51,14 @@ class OpenAILLM(LLMInterface):
         formatted_messages.extend(messages)
 
         # Set up generation parameters
-        if self.config.api_base == "https://api.openai.com/v1" and str(self.model).lower().startswith("o"):
+        if self.config.api_base == "https://api.openai.com/v1" and str(
+            self.model
+        ).lower().startswith("o"):
             # For o-series models
             params = {
                 "model": self.model,
                 "messages": formatted_messages,
-                "max_completion_tokens": kwargs.get("max_tokens", self.config.max_tokens)
+                "max_completion_tokens": kwargs.get("max_tokens", self.config.max_tokens),
             }
         else:
             params = {

--- a/openevolve/llm/openai.py
+++ b/openevolve/llm/openai.py
@@ -51,13 +51,21 @@ class OpenAILLM(LLMInterface):
         formatted_messages.extend(messages)
 
         # Set up generation parameters
-        params = {
-            "model": self.model,
-            "messages": formatted_messages,
-            "temperature": kwargs.get("temperature", self.config.temperature),
-            "top_p": kwargs.get("top_p", self.config.top_p),
-            "max_tokens": kwargs.get("max_tokens", self.config.max_tokens),
-        }
+        if self.config.api_base == "https://api.openai.com/v1" and str(self.model).lower().startswith("o"):
+            # For o-series models
+            params = {
+                "model": self.model,
+                "messages": formatted_messages,
+                "max_completion_tokens": kwargs.get("max_tokens", self.config.max_tokens)
+            }
+        else:
+            params = {
+                "model": self.model,
+                "messages": formatted_messages,
+                "temperature": kwargs.get("temperature", self.config.temperature),
+                "top_p": kwargs.get("top_p", self.config.top_p),
+                "max_tokens": kwargs.get("max_tokens", self.config.max_tokens),
+            }
 
         # Attempt the API call with retries
         retries = kwargs.get("retries", self.config.retries)


### PR DESCRIPTION
### Overview

This pull request fixes an API parameter error that occurred when using o-series models (such as o3) with the official OpenAI API endpoint.

### Background

Previously, when calling the OpenAI API with o-series models, the following error was returned:

```sh
- INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 400 Bad Request"
- WARNING - Error on attempt 1/4: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}. Retrying...
```

This was due to the use of the `max_tokens` parameter, which is not supported by these models. Instead, the API expects the `max_completion_tokens` parameter.

### Fix Details

- The code now checks if both the model name starts with "o" and the API base is `https://api.openai.com/v1`.
- If so, it uses the `max_completion_tokens` parameter instead of `max_tokens` when making the API call.
- For o-series models, parameters such as `temperature` and `top_p` are omitted because the official OpenAI API does not support customizing these values for these models.
- For all other models or endpoints, the original parameters are used.

### Impact

This change ensures compatibility with the latest o-series models on the official OpenAI API, preventing 400 Bad Request errors due to unsupported parameters.

---

If you have any questions or need further clarification, please let me know. Thank you for reviewing this pull request!
