### PR TITLE
feat: add Gemini as a LLM provider

### DIFF
--- a/configs/gemini_config_example.yaml
+++ b/configs/gemini_config_example.yaml
@@ -1,0 +1,101 @@
+# Example configuration for using Google Gemini models with OpenEvolve
+
+# General settings
+max_iterations: 100
+checkpoint_interval: 10
+log_level: INFO
+log_dir: ./logs
+random_seed: 42
+
+# LLM configuration
+llm:
+  # Default values (can be overridden per model)
+  temperature: 0.7
+  top_p: 0.95
+  max_tokens: 4096
+  timeout: 60
+  retries: 3
+  retry_delay: 5
+  
+  # Model ensemble configuration
+  models:
+    # Primary model - Gemini 2.0 Flash
+    - name: "gemini-2.0-flash"
+      provider: "gemini"
+      weight: 0.6
+      # API key can be set here or via GEMINI_API_KEY environment variable
+      # api_key: "YOUR_GEMINI_API_KEY"
+      
+    # Secondary model - Gemini 1.5 Pro
+    - name: "gemini-1.5-pro"
+      provider: "gemini"
+      weight: 0.4
+      # api_key: "YOUR_GEMINI_API_KEY"
+  
+  # Evaluator models (if not specified, uses same as models)
+  evaluator_models:
+    - name: "gemini-2.0-flash"
+      provider: "gemini"
+      weight: 1.0
+      # api_key: "YOUR_GEMINI_API_KEY"
+
+# Prompt configuration
+prompt:
+  system_message: |
+    You are an expert programmer tasked with evolving code to improve its performance.
+    Focus on optimizing the algorithm while maintaining correctness.
+  evaluator_system_message: |
+    You are an expert code evaluator. Analyze the provided metrics and determine
+    if the evolved program is an improvement over the original.
+  num_top_programs: 3
+  num_diverse_programs: 2
+  use_template_stochasticity: true
+
+# Database configuration
+database:
+  in_memory: true
+  population_size: 1000
+  archive_size: 100
+  num_islands: 5
+  elite_selection_ratio: 0.1
+  exploration_ratio: 0.2
+  exploitation_ratio: 0.7
+  feature_dimensions: ["fitness", "complexity"]
+  feature_bins: 10
+  migration_interval: 10
+  migration_rate: 0.1
+  random_seed: 42
+
+# Evaluator configuration
+evaluator:
+  timeout: 30
+  max_retries: 3
+  cascade_evaluation: true
+  cascade_thresholds: [0.5, 0.8]
+  parallel_evaluations: 4
+  use_llm_feedback: true
+  llm_feedback_weight: 0.2
+
+# Evolution settings
+diff_based_evolution: false
+allow_full_rewrites: true
+max_code_length: 10000
+
+# Usage notes:
+# 1. Set your Gemini API key either in this config or via environment variable:
+#    export GEMINI_API_KEY="your-api-key-here"
+#
+# 2. You can mix OpenAI and Gemini models in the same ensemble:
+#    models:
+#      - name: "gpt-4"
+#        provider: "openai"
+#        weight: 0.3
+#      - name: "gemini-2.0-flash"
+#        provider: "gemini"
+#        weight: 0.7
+#
+# 3. Available Gemini models include:
+#    - gemini-2.0-flash (fastest, most cost-effective)
+#    - gemini-2.0-flash-lite (lighter version)
+#    - gemini-1.5-pro (more capable, slower)
+#    - gemini-1.5-flash (balanced performance)

--- a/openevolve/llm/__init__.py
+++ b/openevolve/llm/__init__.py
@@ -4,6 +4,7 @@ LLM module initialization
 
 from openevolve.llm.base import LLMInterface
 from openevolve.llm.ensemble import LLMEnsemble
+from openevolve.llm.gemini import GeminiLLM
 from openevolve.llm.openai import OpenAILLM
 
-__all__ = ["LLMInterface", "OpenAILLM", "LLMEnsemble"]
+__all__ = ["LLMInterface", "OpenAILLM", "GeminiLLM", "LLMEnsemble"]

--- a/openevolve/llm/ensemble.py
+++ b/openevolve/llm/ensemble.py
@@ -8,6 +8,7 @@ import random
 from typing import Dict, List, Optional, Tuple
 
 from openevolve.llm.base import LLMInterface
+from openevolve.llm.gemini import GeminiLLM
 from openevolve.llm.openai import OpenAILLM
 from openevolve.config import LLMModelConfig
 
@@ -21,7 +22,16 @@ class LLMEnsemble:
         self.models_cfg = models_cfg
 
         # Initialize models from the configuration
-        self.models = [OpenAILLM(model_cfg) for model_cfg in models_cfg]
+        self.models = []
+        for model_cfg in models_cfg:
+            # Determine model type based on provider or model name
+            if hasattr(model_cfg, 'provider') and model_cfg.provider == 'gemini':
+                self.models.append(GeminiLLM(model_cfg))
+            elif model_cfg.name.startswith('gemini'):
+                self.models.append(GeminiLLM(model_cfg))
+            else:
+                # Default to OpenAI for backward compatibility
+                self.models.append(OpenAILLM(model_cfg))
 
         # Extract and normalize model weights
         self.weights = [model.weight for model in models_cfg]

--- a/openevolve/llm/gemini.py
+++ b/openevolve/llm/gemini.py
@@ -1,0 +1,124 @@
+"""
+Gemini API interface for LLMs
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from google import genai
+from google.genai import types
+
+from openevolve.config import LLMConfig
+from openevolve.llm.base import LLMInterface
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiLLM(LLMInterface):
+    """LLM interface using Google Gemini API"""
+
+    def __init__(
+        self,
+        model_cfg: Optional[dict] = None,
+    ):
+        self.model = model_cfg.name
+        self.system_message = model_cfg.system_message
+        self.temperature = model_cfg.temperature
+        self.top_p = model_cfg.top_p
+        self.max_tokens = model_cfg.max_tokens
+        self.timeout = model_cfg.timeout
+        self.retries = model_cfg.retries
+        self.retry_delay = model_cfg.retry_delay
+        self.api_key = model_cfg.api_key
+
+        # Set up Gemini client
+        self.client = genai.Client(api_key=self.api_key)
+
+        logger.info(f"Initialized Gemini LLM with model: {self.model}")
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        """Generate text from a prompt"""
+        return await self.generate_with_context(
+            system_message=self.system_message,
+            messages=[{"role": "user", "content": prompt}],
+            **kwargs,
+        )
+
+    async def generate_with_context(
+        self, system_message: str, messages: List[Dict[str, str]], **kwargs
+    ) -> str:
+        """Generate text using a system message and conversational context"""
+        # Format the conversation for Gemini
+        # Gemini doesn't have explicit system messages, so we prepend it to the first user message
+        formatted_content = []
+        
+        # Add system message as the first part of the conversation
+        if system_message:
+            formatted_content.append(f"System: {system_message}\n\n")
+        
+        # Add conversation history
+        for msg in messages:
+            role = msg["role"]
+            content = msg["content"]
+            if role == "user":
+                formatted_content.append(f"User: {content}")
+            elif role == "assistant":
+                formatted_content.append(f"Assistant: {content}")
+            else:
+                # Handle any other roles as user messages
+                formatted_content.append(f"{role}: {content}")
+        
+        # Join all parts into a single prompt
+        full_prompt = "\n\n".join(formatted_content)
+
+        # Set up generation parameters
+        generation_config = types.GenerateContentConfig(
+            temperature=kwargs.get("temperature", self.temperature),
+            top_p=kwargs.get("top_p", self.top_p),
+            max_output_tokens=kwargs.get("max_tokens", self.max_tokens),
+        )
+
+        # Attempt the API call with retries
+        retries = kwargs.get("retries", self.retries)
+        retry_delay = kwargs.get("retry_delay", self.retry_delay)
+        timeout = kwargs.get("timeout", self.timeout)
+
+        for attempt in range(retries + 1):
+            try:
+                response = await asyncio.wait_for(
+                    self._call_api(full_prompt, generation_config), 
+                    timeout=timeout
+                )
+                return response
+            except asyncio.TimeoutError:
+                if attempt < retries:
+                    logger.warning(f"Timeout on attempt {attempt + 1}/{retries + 1}. Retrying...")
+                    await asyncio.sleep(retry_delay)
+                else:
+                    logger.error(f"All {retries + 1} attempts failed with timeout")
+                    raise
+            except Exception as e:
+                if attempt < retries:
+                    logger.warning(
+                        f"Error on attempt {attempt + 1}/{retries + 1}: {str(e)}. Retrying..."
+                    )
+                    await asyncio.sleep(retry_delay)
+                else:
+                    logger.error(f"All {retries + 1} attempts failed with error: {str(e)}")
+                    raise
+
+    async def _call_api(self, prompt: str, generation_config: types.GenerateContentConfig) -> str:
+        """Make the actual API call"""
+        # Use asyncio to run the blocking API call in a thread pool
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(
+            None, 
+            lambda: self.client.models.generate_content(
+                model=self.model,
+                contents=prompt,
+                config=generation_config
+            )
+        )
+        return response.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
     "openai>=1.0.0",
+    "google-genai>=0.1.0",
     "pyyaml>=6.0",
     "numpy>=1.22.0",
     "tqdm>=4.64.0",


### PR DESCRIPTION
This PR adds support for Google Gemini models as an LLM provider in OpenEvolve, enabling users to leverage Gemini's capabilities alongside
or instead of OpenAI models.

## Changes

- Added Gemini LLM implementation (openevolve/llm/gemini.py): New class that interfaces with Google's Gemini API, supporting models like
gemini-2.0-flash and gemini-1.5-pro
- Enhanced model ensemble to automatically detect and instantiate the correct provider (OpenAI or Gemini) based on model name or explicit
provider field
- Updated configuration system to support provider-specific API keys (GEMINI_API_KEY environment variable)
- Added example configuration (configs/gemini_config_example.yaml) demonstrating how to use Gemini models in single or ensemble
configurations
- Added google-genai dependency to project requirements

## Key Features

- Seamless integration with existing ensemble system - mix and match OpenAI and Gemini models
- Support for all Gemini model variants (2.0-flash, 1.5-pro, etc.)
- Maintains backward compatibility - existing OpenAI-only configurations work unchanged
- Automatic provider detection based on model naming convention

## Usage

```yaml
  llm:
    models:
      - name: "gemini-2.0-flash"
        provider: "gemini"
        weight: 0.6
      - name: "gpt-4"
        provider: "openai"
        weight: 0.4
```

Set your API key via environment variable: export GEMINI_API_KEY="your-key-here"

```sh
python openevolve-run.py examples/circle_packing/initial_program.py \
  examples/circle_packing/evaluator.py \
  --config configs/gemini_config_example.yaml \
  --iterations 5
```