### PR TITLE
Feature: Parallel iterations

### DIFF
--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -140,6 +140,7 @@ class DatabaseConfig:
 
     # Evolutionary parameters
     population_size: int = 1000
+    allowed_population_overflow: int = 50
     archive_size: int = 100
     num_islands: int = 5
 
@@ -196,6 +197,7 @@ class Config:
     log_level: str = "INFO"
     log_dir: Optional[str] = None
     random_seed: Optional[int] = None
+    language: str = None
 
     # Component configurations
     llm: LLMConfig = field(default_factory=LLMConfig)

--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -5,6 +5,7 @@ Main controller for OpenEvolve
 import asyncio
 import logging
 import os
+import shutil
 import re
 import time
 import uuid
@@ -216,7 +217,7 @@ class OpenEvolve:
         self.database.log_island_status()
 
         # create temp file to save database snapshots to for process workers to load from
-        temp_db_path = "temp/" + str(uuid.uuid4())
+        temp_db_path = "tmp/" + str(uuid.uuid4())
         self.database.save(temp_db_path, start_iteration)
 
         with concurrent.futures.ProcessPoolExecutor(
@@ -293,7 +294,7 @@ class OpenEvolve:
                 except Exception:
                     logger.exception(f"Error in iteration {iteration}:")
                     continue
-        os.rmdir(temp_db_path)
+        shutil.rmtree(temp_db_path)
 
         # Get the best program using our tracking mechanism
         best_program = None

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -10,7 +10,7 @@ import random
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from Levenshtein import distance, ratio
+from Levenshtein import ratio
 from filelock import FileLock, Timeout
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -307,7 +307,8 @@ class ProgramDatabase:
             logger.warning("No database path specified, skipping save")
             return
 
-        lock_path = save_path + ".lock"
+        lock_name = os.path.basename(save_path) + '.lock'
+        lock_path = os.path.join('tmp/locks', lock_name)
         try:
             with FileLock(lock_path, timeout=10):
                 # Create directory and remove old path if it exists
@@ -371,7 +372,8 @@ class ProgramDatabase:
             logger.info(f"Loaded database metadata with last_iteration={self.last_iteration}")
 
         # Load programs
-        lock_path = path + ".lock"
+        lock_name = os.path.basename(path) + '.lock'
+        lock_path = os.path.join('tmp/locks', lock_name)
         programs_dir = os.path.join(path, "programs")
         try:
             with FileLock(lock_path, timeout=10):

--- a/openevolve/iteration.py
+++ b/openevolve/iteration.py
@@ -1,0 +1,144 @@
+import asyncio
+import os
+import uuid
+import logging
+import time
+from dataclasses import dataclass
+
+from openevolve.database import Program, ProgramDatabase
+from openevolve.config import Config
+from openevolve.evaluator import Evaluator
+from openevolve.llm.ensemble import LLMEnsemble
+from openevolve.prompt.sampler import PromptSampler
+from openevolve.utils.code_utils import (
+    apply_diff,
+    extract_diffs,
+    format_diff_summary,
+    parse_full_rewrite,
+)
+
+
+@dataclass
+class Result:
+    """Resulting program and metrics from an iteration of OpenEvolve"""
+
+    child_program: str = None
+    parent: str = None
+    child_metrics: str = None
+    iteration_time: float = None
+
+
+def run_iteration_sync(iteration: int, config: Config, evaluation_file: str, database_path: str):
+    # setup logger showing PID for current process
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+    logging.basicConfig(
+        level=getattr(logging, config.log_level),
+        format="%(asctime)s - %(levelname)s - PID %(process)d - %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+    logger.info("Starting iteration in PID %s", os.getpid())
+
+    llm_ensemble = LLMEnsemble(config.llm.models)
+    llm_evaluator_ensemble = LLMEnsemble(config.llm.evaluator_models)
+
+    prompt_sampler = PromptSampler(config.prompt)
+    evaluator_prompt_sampler = PromptSampler(config.prompt)
+    evaluator_prompt_sampler.set_templates("evaluator_system_message")
+
+    # Pass random seed to database if specified
+    if config.random_seed is not None:
+        config.database.random_seed = config.random_seed
+
+    # load most recent database snapshot
+    config.database.db_path = database_path
+    database = ProgramDatabase(config.database)
+
+    evaluator = Evaluator(
+        config.evaluator,
+        evaluation_file,
+        llm_evaluator_ensemble,
+        evaluator_prompt_sampler,
+    )
+
+    # Sample parent and inspirations from current island
+    parent, inspirations = database.sample()
+
+    # Build prompt
+    prompt = prompt_sampler.build_prompt(
+        current_program=parent.code,
+        parent_program=parent.code,  # We don't have the parent's code, use the same
+        program_metrics=parent.metrics,
+        previous_programs=[p.to_dict() for p in database.get_top_programs(3)],
+        top_programs=[p.to_dict() for p in inspirations],
+        language=config.language,
+        evolution_round=iteration,
+        allow_full_rewrite=config.allow_full_rewrites,
+    )
+
+    async def _run():
+        result = Result(parent=parent)
+        iteration_start = time.time()
+
+        # Generate code modification
+        try:
+            llm_response = await llm_ensemble.generate_with_context(
+                system_message=prompt["system"],
+                messages=[{"role": "user", "content": prompt["user"]}],
+            )
+
+            # Parse the response
+            if config.diff_based_evolution:
+                diff_blocks = extract_diffs(llm_response)
+
+                if not diff_blocks:
+                    logger.warning(f"Iteration {iteration+1}: No valid diffs found in response")
+                    return
+
+                # Apply the diffs
+                child_code = apply_diff(parent.code, llm_response)
+                changes_summary = format_diff_summary(diff_blocks)
+            else:
+                # Parse full rewrite
+                new_code = parse_full_rewrite(llm_response, config.language)
+
+                if not new_code:
+                    logger.warning(f"Iteration {iteration+1}: No valid code found in response")
+                    return
+
+                child_code = new_code
+                changes_summary = "Full rewrite"
+
+            # Check code length
+            if len(child_code) > config.max_code_length:
+                logger.warning(
+                    f"Iteration {iteration+1}: Generated code exceeds maximum length "
+                    f"({len(child_code)} > {config.max_code_length})"
+                )
+                return
+
+            # Evaluate the child program
+            child_id = str(uuid.uuid4())
+            result.child_metrics = await evaluator.evaluate_program(child_code, child_id)
+
+            # Create a child program
+            result.child_program = Program(
+                id=child_id,
+                code=child_code,
+                language=config.language,
+                parent_id=parent.id,
+                generation=parent.generation + 1,
+                metrics=result.child_metrics,
+                metadata={
+                    "changes": changes_summary,
+                    "parent_metrics": parent.metrics,
+                },
+            )
+
+        except Exception as e:
+            logger.exception("Error in PID %s:", os.getpid())
+
+        result.iteration_time = time.time() - iteration_start
+        return result
+
+    return asyncio.run(_run())

--- a/openevolve/llm/ensemble.py
+++ b/openevolve/llm/ensemble.py
@@ -11,7 +11,7 @@ from openevolve.llm.base import LLMInterface
 from openevolve.llm.openai import OpenAILLM
 from openevolve.config import LLMModelConfig
 
-# logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LLMEnsemble:
@@ -28,7 +28,7 @@ class LLMEnsemble:
         total = sum(self.weights)
         self.weights = [w / total for w in self.weights]
 
-        logging.info(
+        logger.info(
             f"Initialized LLM ensemble with models: "
             + ", ".join(
                 f"{model.name} (weight: {weight:.2f})"

--- a/openevolve/llm/ensemble.py
+++ b/openevolve/llm/ensemble.py
@@ -11,7 +11,7 @@ from openevolve.llm.base import LLMInterface
 from openevolve.llm.openai import OpenAILLM
 from openevolve.config import LLMModelConfig
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
 
 
 class LLMEnsemble:
@@ -28,7 +28,7 @@ class LLMEnsemble:
         total = sum(self.weights)
         self.weights = [w / total for w in self.weights]
 
-        logger.info(
+        logging.info(
             f"Initialized LLM ensemble with models: "
             + ", ".join(
                 f"{model.name} (weight: {weight:.2f})"

--- a/openevolve/utils/__init__.py
+++ b/openevolve/utils/__init__.py
@@ -10,7 +10,6 @@ from openevolve.utils.async_utils import (
 )
 from openevolve.utils.code_utils import (
     apply_diff,
-    calculate_edit_distance,
     extract_code_language,
     extract_diffs,
     format_diff_summary,
@@ -32,7 +31,6 @@ __all__ = [
     "retry_async",
     "run_in_executor",
     "apply_diff",
-    "calculate_edit_distance",
     "extract_code_language",
     "extract_diffs",
     "format_diff_summary",

--- a/openevolve/utils/code_utils.py
+++ b/openevolve/utils/code_utils.py
@@ -144,42 +144,6 @@ def format_diff_summary(diff_blocks: List[Tuple[str, str]]) -> str:
     return "\n".join(summary)
 
 
-def calculate_edit_distance(code1: str, code2: str) -> int:
-    """
-    Calculate the Levenshtein edit distance between two code snippets
-
-    Args:
-        code1: First code snippet
-        code2: Second code snippet
-
-    Returns:
-        Edit distance (number of operations needed to transform code1 into code2)
-    """
-    if code1 == code2:
-        return 0
-
-    # Simple implementation of Levenshtein distance
-    m, n = len(code1), len(code2)
-    dp = [[0 for _ in range(n + 1)] for _ in range(m + 1)]
-
-    for i in range(m + 1):
-        dp[i][0] = i
-
-    for j in range(n + 1):
-        dp[0][j] = j
-
-    for i in range(1, m + 1):
-        for j in range(1, n + 1):
-            cost = 0 if code1[i - 1] == code2[j - 1] else 1
-            dp[i][j] = min(
-                dp[i - 1][j] + 1,  # deletion
-                dp[i][j - 1] + 1,  # insertion
-                dp[i - 1][j - 1] + cost,  # substitution
-            )
-
-    return dp[m][n]
-
-
 def extract_code_language(code: str) -> str:
     """
     Try to determine the language of a code snippet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "pyyaml>=6.0",
     "numpy>=1.22.0",
     "tqdm>=4.64.0",
+    "levenshtein>=0.27.1",
+    "filelock>=3.18.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add parallel iterations along with a couple of bug fixes/improvements. I would consider this a pretty important feature because of the significant speedup it provides to training. This is the implementation that I tried and has worked for my use cases.

Primary changes:

- Use `concurrent.futures` in `controller.py` to spawn processes for performing the iterations of training
- Moved most of the iteration logic inside the function `run_iteration_sync` in a new file `iteration.py` which is run by the workers to allow concurrent execution
- Pass config into spawned processes to initialize new instances of `LLMEnsemble` and `ProgramDatabase` (these classes are not pickleable so this is the best approach I could think of to use these classes in each of the worker processes)
- As a consequence of this approach a snapshot of the database needs to be saved in the root process every iteration and each new process needs to load it

Minor changes:

- The `calculate_edit_distance` function was crashing the database when I was using it and since there's already libraries that do this routine I ended up using one of them (`levenshtein`)
- Replaced the use of the Levenshtein distance with a ratio in `_calculate_island_diversity` since it's easier to read
- Replaced the use of the Levenshtein distance with a ratio in `_calculate_feature_coords` since it's normalized for code length
- Introduced `allowed_population_overflow` since otherwise the database was adding and removing a program every iteration when it reach the allowed program limit
- Added logging for MAP-Elite features
