### PR TITLE
Refine prompt context and bump version to 0.0.8

### DIFF
--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -263,13 +263,18 @@ class OpenEvolve:
             # Get artifacts for the parent program if available
             parent_artifacts = self.database.get_artifacts(parent.id)
 
+            # Get actual top programs for prompt context (separate from inspirations)
+            # This ensures the LLM sees only high-performing programs as examples
+            actual_top_programs = self.database.get_top_programs(5)
+
             # Build prompt
             prompt = self.prompt_sampler.build_prompt(
                 current_program=parent.code,
                 parent_program=parent.code,  # We don't have the parent's code, use the same
                 program_metrics=parent.metrics,
                 previous_programs=[p.to_dict() for p in self.database.get_top_programs(3)],
-                top_programs=[p.to_dict() for p in inspirations],
+                top_programs=[p.to_dict() for p in actual_top_programs],  # Use actual top programs
+                inspirations=[p.to_dict() for p in inspirations],  # Pass inspirations separately
                 language=self.language,
                 evolution_round=i,
                 diff_based_evolution=self.config.diff_based_evolution,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openevolve"
-version = "0.0.7"
+version = "0.0.8"
 description = "Open-source implementation of AlphaEvolve"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openevolve",
-    version="0.0.7",
+    version="0.0.8",
     packages=find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Updated the controller to use actual top programs for prompt context, ensuring the LLM receives only high-performing examples, and passed inspirations separately. Incremented the package version to 0.0.8 in both pyproject.toml and setup.py.

fixes #92 