### PR TITLE
Minor improvement 

### DIFF
--- a/openevolve/llm/ensemble.py
+++ b/openevolve/llm/ensemble.py
@@ -57,9 +57,10 @@ class LLMEnsemble:
 
     def _sample_model(self) -> LLMInterface:
         """Sample a model from the ensemble based on weights"""
-        logger.info(f"Sampled model: {vars(self.models[index])['model']}")
         index = self.random_state.choices(range(len(self.models)), weights=self.weights, k=1)[0]
-        return self.models[index]
+        sampled_model = self.models[index]
+        logger.info(f"Sampled model: {vars(sampled_model)['model']}")
+        return sampled_model
 
     async def generate_multiple(self, prompt: str, n: int, **kwargs) -> List[str]:
         """Generate multiple texts in parallel"""

--- a/scripts/templates/program_page.html
+++ b/scripts/templates/program_page.html
@@ -27,9 +27,36 @@
     <pre>{{ program_data.code }}</pre>
     <h2>Prompts:</h2>
     <ul>
+        {#-- recursive “display” macro --#}
+        {% macro display(val) %}
+        {% if val is mapping %}
+            <ul>
+            {% for k, v in val.items() %}
+                <li>
+                <strong>{{ k|e }}:</strong>
+                {{ display(v) }}
+                </li>
+            {% endfor %}
+            </ul>
+        {% elif val is sequence and not val is string %}
+            <ul>
+            {% for item in val %}
+                <li>{{ display(item) }}</li>
+            {% endfor %}
+            </ul>
+        {% else %}
+            <pre>{{ val|e }}</pre>
+        {% endif %}
+        {% endmacro %}
+        {#-- loop over every prompts --#}
+        <div class="prompts">
         {% for key, value in program_data.prompts.items() %}
-            <li><strong>{{ key }}:</strong> <pre style="white-space: pre-wrap; word-break: break-word;">{{ value }}</pre></li>
+            <section>
+            <h3>{{ key|title }}</h3>
+            {{ display(value) }}
+            </section>
         {% endfor %}
+        </div>
     </ul>
     {% if artifacts_json %}
     <h2>Artifacts:</h2>


### PR DESCRIPTION
This include two minor quality of life improvements:

- Add info print in _sample_model() to show which model is sampled in the current iteration. Particularly useful when using multiple models from the same endpoint (e.g. openrouter).
 
-  Improve the prompt display in the /program route of the web visualizer. Here is an example before and after the change (after 'Prompts:'): [web_visualizer_compare.zip](https://github.com/user-attachments/files/20929538/web_visualizer_compare.zip)