### PR TITLE
Add nonnegative and not nan check to evalutor.py in the circle_packing example

### DIFF
--- a/examples/circle_packing/evaluator.py
+++ b/examples/circle_packing/evaluator.py
@@ -36,6 +36,15 @@ def validate_packing(centers, radii):
     """
     n = centers.shape[0]
 
+    # Check if radii are nonnegative and not nan
+    for i in range(n):
+        if(radii[i] < 0):
+            print(f"Circle {i} has negative radius {radii[i]}")
+            return False
+        elif(np.isnan(radii[i])):
+            print(f"Circle {i} has nan radius")
+            return False
+
     # Check if circles are inside the unit square
     for i in range(n):
         x, y = centers[i]


### PR DESCRIPTION
I've been running some local tests, and often some LLM models return packings with negative or nan radii. Added this simple check to the evaluator.py file in the circle_packing example.