### PR TITLE
fix: MAP-Elite complexity binning issue #147

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -268,6 +268,156 @@ class TestProgramDatabase(unittest.TestCase):
         # Restore original limit
         self.db.config.population_size = original_limit
 
+    def test_calculate_complexity_bin_adaptive(self):
+        """Test adaptive complexity binning with multiple programs"""
+        # Add programs with different complexities
+        programs = [
+            Program(id="short", code="x=1", metrics={"score": 0.5}),
+            Program(id="medium", code="def func():\n    return x*2\n    pass", metrics={"score": 0.5}),
+            Program(id="long", code="def complex_function():\n    result = []\n    for i in range(100):\n        result.append(i*2)\n    return result", metrics={"score": 0.5}),
+        ]
+        
+        for program in programs:
+            self.db.add(program)
+        
+        # Test binning for different complexity values
+        short_bin = self.db._calculate_complexity_bin(len("x=1"))
+        medium_bin = self.db._calculate_complexity_bin(len("def func():\n    return x*2\n    pass"))
+        long_bin = self.db._calculate_complexity_bin(len("def complex_function():\n    result = []\n    for i in range(100):\n        result.append(i*2)\n    return result"))
+        
+        # Bins should be different and within valid range
+        self.assertNotEqual(short_bin, long_bin)
+        self.assertGreaterEqual(short_bin, 0)
+        self.assertLess(short_bin, self.db.feature_bins)
+        self.assertGreaterEqual(long_bin, 0)
+        self.assertLess(long_bin, self.db.feature_bins)
+
+    def test_calculate_complexity_bin_cold_start(self):
+        """Test complexity binning during cold start (< 2 programs)"""
+        # Empty database - should use fixed range
+        bin_idx = self.db._calculate_complexity_bin(500)
+        
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+        
+        # Add one program - still cold start
+        program = Program(id="single", code="x=1", metrics={"score": 0.5})
+        self.db.add(program)
+        
+        bin_idx = self.db._calculate_complexity_bin(500)
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+
+    def test_calculate_diversity_bin_adaptive(self):
+        """Test adaptive diversity binning with multiple programs"""
+        # Add programs with different code structures for diversity testing
+        programs = [
+            Program(id="simple", code="x = 1", metrics={"score": 0.5}),
+            Program(id="function", code="def add(a, b):\n    return a + b", metrics={"score": 0.5}),
+            Program(id="loop", code="for i in range(10):\n    print(i)\n    x += i", metrics={"score": 0.5}),
+            Program(id="complex", code="class MyClass:\n    def __init__(self):\n        self.data = []\n    def process(self, items):\n        return [x*2 for x in items]", metrics={"score": 0.5}),
+        ]
+        
+        for program in programs:
+            self.db.add(program)
+        
+        # Test binning for different diversity values
+        # Use fast diversity to calculate test values
+        simple_prog = programs[0]
+        complex_prog = programs[3]
+        
+        # Calculate diversity for simple vs complex programs
+        simple_diversity = self.db._fast_code_diversity(simple_prog.code, complex_prog.code)
+        
+        # Test the binning
+        bin_idx = self.db._calculate_diversity_bin(simple_diversity)
+        
+        # Should be within valid range
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+
+    def test_calculate_diversity_bin_cold_start(self):
+        """Test diversity binning during cold start (< 2 programs)"""
+        # Empty database - should use fixed range
+        bin_idx = self.db._calculate_diversity_bin(500.0)
+        
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+        
+        # Add one program - still cold start
+        program = Program(id="single", code="x=1", metrics={"score": 0.5})
+        self.db.add(program)
+        
+        bin_idx = self.db._calculate_diversity_bin(500.0)
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+
+    def test_calculate_diversity_bin_identical_programs(self):
+        """Test diversity binning when all programs have identical diversity"""
+        # Add multiple identical programs
+        for i in range(3):
+            program = Program(
+                id=f"identical_{i}",
+                code="x = 1",  # Same code
+                metrics={"score": 0.5}
+            )
+            self.db.add(program)
+        
+        # Test binning - should handle zero range gracefully
+        bin_idx = self.db._calculate_diversity_bin(0.0)
+        
+        self.assertGreaterEqual(bin_idx, 0)
+        self.assertLess(bin_idx, self.db.feature_bins)
+
+    def test_fast_code_diversity_function(self):
+        """Test the _fast_code_diversity function"""
+        # Test identical code
+        code1 = "def test(): pass"
+        code2 = "def test(): pass"
+        diversity = self.db._fast_code_diversity(code1, code2)
+        self.assertEqual(diversity, 0.0)
+        
+        # Test different code
+        code1 = "x = 1"
+        code2 = "def complex_function():\n    return [i*2 for i in range(100)]"
+        diversity = self.db._fast_code_diversity(code1, code2)
+        self.assertGreater(diversity, 0.0)
+        
+        # Test length difference
+        short_code = "x = 1"
+        long_code = "x = 1" + "a" * 100
+        diversity = self.db._fast_code_diversity(short_code, long_code)
+        self.assertGreater(diversity, 0.0)
+
+    def test_diversity_feature_integration(self):
+        """Test diversity feature calculation in feature coordinates"""
+        # Add programs with different structures
+        programs = [
+            Program(id="prog1", code="x = 1", metrics={"score": 0.5}),
+            Program(id="prog2", code="def func():\n    return 2", metrics={"score": 0.5}),
+            Program(id="prog3", code="for i in range(5):\n    print(i)", metrics={"score": 0.5}),
+        ]
+        
+        for program in programs:
+            self.db.add(program)
+        
+        # Create a test program with diversity feature enabled
+        test_config = self.db.config
+        test_config.feature_dimensions = ["score", "complexity", "diversity"]
+        
+        test_program = Program(id="test", code="def test(): return 42", metrics={"score": 0.7})
+        
+        # Calculate feature coordinates - should include diversity dimension
+        coords = self.db._calculate_feature_coords(test_program)
+        
+        # Should have 3 coordinates for score, complexity, and diversity
+        self.assertEqual(len(coords), 3)
+        
+        # All coordinates should be within valid range
+        for coord in coords:
+            self.assertGreaterEqual(coord, 0)
+            self.assertLess(coord, self.db.feature_bins)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fixed critical issue where all programs were binned to highest complexity bin
- Replaced problematic fixed-scale binning with adaptive binning
- Added helper methods for complexity and diversity binning

## Changes
- `_calculate_complexity_bin()`: Uses actual program complexity range
- `_calculate_diversity_bin()`: Uses reasonable fixed range for edit distances
- Cold start handling with sensible defaults
- Proper normalization and clamping to valid bin ranges

## Impact
- MAP-Elites algorithm now works effectively with proper feature diversity
- Programs distributed across all bins instead of clustering in highest bin
- Backward compatible with existing functionality

Fixes #147

🤖 Generated with [Claude Code](https://claude.ai/code)