### PR TITLE
modify for MAP-Elite Algorithm

### DIFF
--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -166,7 +166,8 @@ class DatabaseConfig:
     diversity_metric: str = "edit_distance"  # Options: "edit_distance", "feature_based"
 
     # Feature map dimensions for MAP-Elites
-    feature_dimensions: List[str] = field(default_factory=lambda: ["score", "complexity"])
+    # feature_dimensions: List[str] = field(default_factory=lambda: ["score", "complexity"])
+    feature_dimensions: List[str] = field(default_factory=lambda: ["complexity"])
     feature_bins: int = 10
 
     # Migration parameters for island-based evolution

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -105,7 +105,8 @@ class ProgramDatabase:
 
         # Feature grid for MAP-Elites
         self.feature_map: Dict[str, str] = {}
-        self.feature_bins = config.feature_bins
+        self.feature_bins = max(config.feature_bins,
+                                int(pow(config.archive_size, 1 / len(config.feature_dimensions)) + 0.99))
 
         # Island populations
         self.islands: List[Set[str]] = [set() for _ in range(config.num_islands)]
@@ -210,6 +211,11 @@ class ProgramDatabase:
                     existing_fitness = safe_numeric_average(existing_program.metrics)
                     logger.info("MAP-Elites cell improved: %s (fitness: %.3f -> %.3f)", 
                                coords_dict, existing_fitness, new_fitness)
+                    
+                    # use MAP-Elites to manage archive
+                    if existing_program_id in self.archive:
+                        self.archive.discard(existing_program_id)
+                        self.archive.add(program.id)
             
             self.feature_map[feature_key] = program.id
 


### PR DESCRIPTION
By using MAP-Elite to manage archive from which the OpenEvolve get the parents for the next generations.
Use ["complexity"] as feature_dimensions, because if we use ["score", "complexity"], the effectiveness of Evolution degrade significantly, according to my test.
