### PR TITLE
Warn when 'combined_score' metric is missing

### DIFF
--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -249,6 +249,22 @@ class OpenEvolve:
             )
 
             self.database.add(initial_program)
+            
+            # Check if combined_score is present in the metrics
+            if "combined_score" not in initial_metrics:
+                # Calculate average of numeric metrics
+                numeric_metrics = [
+                    v for v in initial_metrics.values() 
+                    if isinstance(v, (int, float)) and not isinstance(v, bool)
+                ]
+                if numeric_metrics:
+                    avg_score = sum(numeric_metrics) / len(numeric_metrics)
+                    logger.warning(
+                        f"⚠️  No 'combined_score' metric found in evaluation results. "
+                        f"Using average of all numeric metrics ({avg_score:.4f}) for evolution guidance. "
+                        f"For better evolution results, please modify your evaluator to return a 'combined_score' "
+                        f"metric that properly weights different aspects of program performance."
+                    )
         else:
             logger.info(
                 f"Skipping initial program addition (resuming from iteration {start_iteration} "

--- a/openevolve/process_parallel.py
+++ b/openevolve/process_parallel.py
@@ -463,6 +463,21 @@ class ProcessParallelController:
                             for k, v in child_program.metrics.items()
                         ])
                         logger.info(f"Metrics: {metrics_str}")
+                        
+                        # Check if this is the first program without combined_score
+                        if not hasattr(self, '_warned_about_combined_score'):
+                            self._warned_about_combined_score = False
+                        
+                        if "combined_score" not in child_program.metrics and not self._warned_about_combined_score:
+                            from openevolve.utils.metrics_utils import safe_numeric_average
+                            avg_score = safe_numeric_average(child_program.metrics)
+                            logger.warning(
+                                f"⚠️  No 'combined_score' metric found in evaluation results. "
+                                f"Using average of all numeric metrics ({avg_score:.4f}) for evolution guidance. "
+                                f"For better evolution results, please modify your evaluator to return a 'combined_score' "
+                                f"metric that properly weights different aspects of program performance."
+                            )
+                            self._warned_about_combined_score = True
                     
                     # Check for new best
                     if self.database.best_program_id == child_program.id:


### PR DESCRIPTION
Adds warnings and fallback logic to use the average of numeric metrics when 'combined_score' is not present in evaluation results. This helps guide evolution and informs users to provide a properly weighted 'combined_score' for better results.