### PR TITLE
Pass timeout to OpenAI client object

### DIFF
--- a/openevolve/llm/openai.py
+++ b/openevolve/llm/openai.py
@@ -38,6 +38,7 @@ class OpenAILLM(LLMInterface):
         self.client = openai.OpenAI(
             api_key=self.api_key,
             base_url=self.api_base,
+            timeout=self.timeout,
         )
 
         # Only log unique models to reduce duplication


### PR DESCRIPTION
Not doing this makes client use the default 10 minute timeout. It causes client to stop generation after 10 minutes even if timeout option is higher, making models with slow inference unusable.