### PR TITLE
Fix metadata field access in PromptSampler (#203)

### DIFF
--- a/openevolve/prompt/sampler.py
+++ b/openevolve/prompt/sampler.py
@@ -249,7 +249,7 @@ class PromptSampler:
 
         for i, program in enumerate(reversed(selected_previous)):
             attempt_number = len(previous_programs) - i
-            changes = program.get("changes", "Unknown changes")
+            changes = program.get("metadata", {}).get("changes", "Unknown changes")
 
             # Format performance metrics using safe formatting
             performance_parts = []
@@ -264,7 +264,7 @@ class PromptSampler:
             performance_str = ", ".join(performance_parts)
 
             # Determine outcome based on comparison with parent (only numeric metrics)
-            parent_metrics = program.get("parent_metrics", {})
+            parent_metrics = program.get("metadata", {}).get("parent_metrics", {})
             outcome = "Mixed results"
 
             # Safely compare only numeric metrics


### PR DESCRIPTION
- Fix changes field access: program.get("changes") → program.get("metadata", {}).get("changes")
- Fix parent_metrics field access: program.get("parent_metrics") → program.get("metadata", {}).get("parent_metrics")

These fields are stored in Program.metadata but were being accessed at the top level, causing evolution history to always show "Unknown changes" instead of actual modifications.

Fixes #203