### PR TITLE
escape html in sidebar

### DIFF
--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -49,7 +49,7 @@ export function showSidebarContent(d, fromHover = false) {
     // Helper to render tab content
     function renderSidebarTabContent(tabName, d, children) {
         if (tabName === 'Code') {
-            return `<pre class="sidebar-code-pre">${d.code}</pre>`;
+            return `<pre class="sidebar-code-pre">${escapeHtml(d.code)}</pre>`;
         }
         if (tabName === 'Prompts') {
             // Prompt select logic
@@ -328,4 +328,15 @@ export function openInNewTab(event, d) {
 
 export function setSidebarSticky(val) {
     sidebarSticky = val;
+}
+
+// Helper to escape HTML so code can be shown verbatim inside <pre>
+function escapeHtml(str) {
+    if (str === undefined || str === null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }


### PR DESCRIPTION
This fixes the rendering of things that look like html in the code, like ``#include <iostream>`` in C++ in the sidebar. For some reason this does not seem to be a problem on the stand-alone program page.