### PR TITLE
fix(scripts/static/js/sidebar.js): fixed unicode escape error in disp…

### DIFF
--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -405,6 +405,19 @@ export function showSidebarContent(d, fromHover = false) {
                  }
                  // Show only the selected prompt
                  let promptVal = promptMap[lastPromptKey];
+                 
+                  // Handle unicode escape for artifacts JSON display
+                 if (lastPromptKey === 'artifacts' && typeof promptVal === 'string') {
+                     try {
+                         // Parse and stringify to properly escape unicode
+                         const parsed = JSON.parse(promptVal);
+                         promptVal = JSON.stringify(parsed, null, 2);
+                     } catch (e) {
+                         // If parsing fails, use original value
+                         console.warn('Failed to parse artifacts JSON for unicode escape:', e);
+                     }
+                 }
+
                  let promptHtml = `<pre class="sidebar-pre">${promptVal ?? ''}</pre>`;
                  return selectHtml + promptHtml;
              }


### PR DESCRIPTION
As a Chinese developer I found that Unicode Characters in artifacts can not be display correctly, I add a JSON parse function  for this.(pool English)
## before
<img width="1913" height="923" alt="image" src="https://github.com/user-attachments/assets/96a93bd1-f974-4bde-9550-51a830c8a037" />

## after
<img width="1890" height="873" alt="截屏2025-12-09 12 03 45" src="https://github.com/user-attachments/assets/b1e0dcd3-dd8c-4ffb-ab14-3243fe89a52d" />