### PR TITLE
fix(scripts/static/js/sidebar.js): fixed unicode escape error in disp…

### DIFF
--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -405,6 +405,19 @@ export function showSidebarContent(d, fromHover = false) {
                  }
                  // Show only the selected prompt
                  let promptVal = promptMap[lastPromptKey];
+                 
+                 // Handle unicode escape for artifacts JSON display
+                 if (lastPromptKey === 'artifacts' && typeof promptVal === 'string') {
+                     try {
+                         // Parse and stringify to properly escape unicode
+                         const parsed = JSON.parse(promptVal);
+                         promptVal = JSON.stringify(parsed, null, 2);
+                     } catch (e) {
+                         // If parsing fails, use original value
+                         console.warn('Failed to parse artifacts JSON for unicode escape:', e);
+                     }
+                 }
+
                  let promptHtml = `<pre class="sidebar-pre">${promptVal ?? ''}</pre>`;
                  return selectHtml + promptHtml;
              }


### PR DESCRIPTION
fix(scripts/static/js/sidebar.js): fixed unicode escape error in displaying artifacts in the sidebar

As a Chinese developer I found that Unicode Characters in artifacts can not be display correctly, I add a JSON parse function for this.(pool English)

# before
<img width="1878" height="874" alt="截屏2025-12-09 13 02 04" src="https://github.com/user-attachments/assets/d106e6db-a27f-41fe-90a2-2b44708f930b" />

# after
<img width="1887" height="862" alt="截屏2025-12-09 13 03 14" src="https://github.com/user-attachments/assets/92e7750e-db30-4682-b961-c918b54e8968" />
