### PR TITLE
Fix island population counting per child program

### DIFF
--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -288,7 +288,6 @@ class DatabaseConfig:
     population_size: int = 1000
     archive_size: int = 100
     num_islands: int = 5
-    programs_per_island: Optional[int] = None
 
     # Selection parameters
     elite_selection_ratio: float = 0.1

--- a/openevolve/process_parallel.py
+++ b/openevolve/process_parallel.py
@@ -445,12 +445,6 @@ class ProcessParallelController:
         next_iteration = current_iteration
         completed_iterations = 0
 
-        # Island management
-        programs_per_island = self.config.database.programs_per_island or max(
-            1, max_iterations // (self.config.database.num_islands * 10)
-        )
-        current_island_counter = 0
-
         # Early stopping tracking
         early_stopping_enabled = self.config.early_stopping_patience is not None
         if early_stopping_enabled:
@@ -543,16 +537,12 @@ class ProcessParallelController:
                         )
 
                     # Island management
-                    if (
-                        completed_iteration > start_iteration
-                        and current_island_counter >= programs_per_island
-                    ):
-                        self.database.next_island()
-                        current_island_counter = 0
-                        logger.debug(f"Switched to island {self.database.current_island}")
-
-                    current_island_counter += 1
-                    self.database.increment_island_generation()
+                    # get current program island id
+                    island_id = child_program.metadata.get(
+                        "island", self.database.current_island
+                    )
+                    #use this to increment island generation
+                    self.database.increment_island_generation(island_idx=island_id)
 
                     # Check migration
                     if self.database.should_migrate():


### PR DESCRIPTION
Previously, when a new child_program was generated, the population counter
of the `database.current_island` was incremented instead of the child_program's actual island.

This change updates the logic to increment the population of the child_program's
real island. As part of this fix, the unused `current_island_counter` and
`program_per_island configuration` were removed.

### Follow-up
It appears that `database.current_island` is now only used during initial
program insertion. The related management logic may be removable in a
follow-up change.


Fixes #351