### PR TITLE
Error in some Anthropic models when both top_k and temperature are passed

### DIFF
--- a/examples/circle_packing/config_phase_1_anthropic.yaml
+++ b/examples/circle_packing/config_phase_1_anthropic.yaml
@@ -1,0 +1,53 @@
+# Configuration for circle packing constructor evolution (n=26)
+max_iterations: 100 # Increased iterations
+checkpoint_interval: 10
+log_level: "INFO"
+
+# LLM configuration
+llm:
+  primary_model: "claude-sonnet-4-5-20250929"
+  primary_model_weight: 0.8
+  secondary_model: "claude-opus-4-5-20251101"
+  secondary_model_weight: 0.2
+  api_base: "https://api.anthropic.com/v1"
+  api_key: "${ANTHROPIC_API_KEY}"
+  temperature: 0.7
+  max_tokens: 8192
+  timeout: 600
+
+# Prompt configuration
+prompt:
+  system_message: |
+    You are an expert mathematician specializing in circle packing problems and computational geometry. Your task is to improve a constructor function that directly produces a specific arrangement of 26 circles in a unit square, maximizing the sum of their radii. The AlphaEvolve paper achieved a sum of 2.635 for n=26.
+
+    Key geometric insights:
+    - Circle packings often follow hexagonal patterns in the densest regions
+    - Maximum density for infinite circle packing is pi/(2*sqrt(3)) ≈ 0.9069
+    - Edge effects make square container packing harder than infinite packing
+    - Circles can be placed in layers or shells when confined to a square
+    - Similar radius circles often form regular patterns, while varied radii allow better space utilization
+    - Perfect symmetry may not yield the optimal packing due to edge effects
+
+    Focus on designing an explicit constructor that places each circle in a specific position, rather than an iterative search algorithm.
+  num_top_programs: 3
+  use_template_stochasticity: true
+
+# Database configuration
+database:
+  population_size: 60 # Increased population for more diversity
+  archive_size: 25
+  num_islands: 4
+  elite_selection_ratio: 0.3
+  exploitation_ratio: 0.7
+
+# Evaluator configuration
+evaluator:
+  timeout: 60
+  cascade_evaluation: true
+  cascade_thresholds: [0.5, 0.75]
+  parallel_evaluations: 4
+  use_llm_feedback: false
+
+# Evolution settings
+diff_based_evolution: false # Use full rewrites instead of diffs
+allow_full_rewrites: true # Allow full rewrites for constructor functions

--- a/examples/circle_packing/config_phase_2_anthropic.yaml
+++ b/examples/circle_packing/config_phase_2_anthropic.yaml
@@ -1,0 +1,60 @@
+# Configuration for breaking through the circle packing plateau
+max_iterations: 100
+checkpoint_interval: 10
+log_level: "INFO"
+
+# LLM configuration
+llm:
+  primary_model: "claude-sonnet-4-5-20250929"
+  primary_model_weight: 0.8
+  secondary_model: "claude-opus-4-5-20251101"
+  secondary_model_weight: 0.2
+  api_base: "https://api.anthropic.com/v1"
+  api_key: "${ANTHROPIC_API_KEY}"
+  temperature: 0.7
+  top_p: null
+  max_tokens: 8192
+  timeout: 600
+
+# Prompt configuration
+prompt:
+  system_message: |
+    You are an expert mathematician specializing in circle packing problems and computational geometry. We're trying to reach the AlphaEvolve target of 2.635 for the sum of radii when packing 26 circles in a unit square. The current implementation has plateaued at 2.377, so we need significant improvements.
+
+    Key insights to explore:
+    1. The optimal arrangement likely involves variable-sized circles
+    2. A pure hexagonal arrangement may not be optimal due to edge effects
+    3. The densest known circle packings often use a hybrid approach
+    4. STRONGLY RECOMMENDED: Formulate this as a constrained optimization problem.
+       - Use `scipy.optimize.minimize` with the 'SLSQP' method.
+       - Define the objective function as minimizing the negative sum of radii.
+       - Define constraints to ensure no circle overlaps and all circles stay within bounds.
+       - This approach is mathematically superior to custom physics simulations for this specific problem.
+    5. Consider strategic placement of circles at square corners and edges
+    6. Adjusting the pattern to place larger circles at the center and smaller at the edges
+    7. The math literature suggests special arrangements for specific values of n
+
+    Focus on breaking through the plateau by using numerical optimization libraries like scipy rather than writing custom solvers.
+  num_top_programs: 4
+  use_template_stochasticity: true
+
+# Database configuration
+database:
+  population_size: 70 # Larger population for more diversity
+  archive_size: 30
+  num_islands: 5
+  elite_selection_ratio: 0.3
+  exploitation_ratio: 0.6 # Slightly lower to encourage exploration
+
+# Evaluator configuration
+evaluator:
+  timeout: 90 # Extended timeout to allow for more complex optimization
+  cascade_evaluation: true
+  cascade_thresholds: [0.5, 0.8]
+  parallel_evaluations: 4
+  use_llm_feedback: false
+
+# Evolution settings
+diff_based_evolution: false
+allow_full_rewrites: true # Definitely allow full rewrites
+max_code_length: 100000

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -64,8 +64,8 @@ class LLMModelConfig:
 
     # Generation parameters
     system_message: Optional[str] = None
-    temperature: float = None
-    top_p: float = None
+    temperature: float | None = None
+    top_p: float | None = None
     max_tokens: int = None
 
     # Request parameters
@@ -93,8 +93,8 @@ class LLMConfig(LLMModelConfig):
 
     # Generation parameters
     system_message: Optional[str] = "system_message"
-    temperature: float = 0.7
-    top_p: float = 0.95
+    temperature: float | None = 0.7
+    top_p: float | None = None
     max_tokens: int = 4096
 
     # Request parameters
@@ -425,10 +425,21 @@ class Config:
             except re.error as e:
                 raise ValueError(f"Invalid regex pattern in diff_pattern: {e}")
 
+        # Remove None values for temperature and top_p to avoid dacite type errors;
+        # alternatively, pass check_types=False to dacite.from_dict, but that can hide other issues
+        if "llm" in config_dict:
+            if "temperature" in config_dict["llm"] and config_dict["llm"]["temperature"] is None:
+                del config_dict["llm"]["temperature"]
+            if "top_p" in config_dict["llm"] and config_dict["llm"]["top_p"] is None:
+                del config_dict["llm"]["top_p"]
+
         config: Config = dacite.from_dict(
             data_class=cls,
             data=config_dict,
-            config=dacite.Config(cast=[List, Union], forward_references={"LLMInterface": Any}),
+            config=dacite.Config(
+                cast=[List, Union],
+                forward_references={"LLMInterface": Any},
+            ),
         )
 
         if config.database.random_seed is None and config.random_seed is not None:


### PR DESCRIPTION
When using certain Anthropic models, passing both `temperature` and `top_p` results in an error.

```yaml
llm:
  api_base: "https://api.anthropic.com/v1"
  temperature: 0.7
  top_p: 0.95
```

```
Error on attempt 1/4: Error code: 400 - {'error': {'code': 'invalid_request_error', 'message': '`temperature` and `top_p` cannot both be specified for this model. Please use only one.', 'type': 'invalid_request_error', 'param': None}}. Retrying...
```

It is not possible to omit one of the parameters or to set them to `null` because the values are passed by default.

This PR makes the parameters `temperature` and `top_p` optional.

I tested it adding alternative configurations for the circle packing example.

The results  I obtained  look better than the documented ones. Actually, better than the reference (someone have a look because I might be overseeing something).

```bash
Evolution complete!
Best program metrics:
  validity: 1.0000
  sum_radii: 2.6360
  target_ratio: 1.0004
  combined_score: 1.0004
  eval_time: 60.8053
```

```json
{
  "id": "82ab7add-e783-4a71-a605-d8099259ff84",
  "generation": 5,
  "iteration": 85,
  "timestamp": 1767982561.3161228,
  "parent_id": "8e2dc578-5bde-493f-a13f-c7b2be33b846",
  "metrics": {
    "validity": 1.0,
    "sum_radii": 2.6359832412776205,
    "target_ratio": 1.0003731465949224,
    "combined_score": 1.0003731465949224,
    "eval_time": 60.80532908439636
  },
  "language": "python",
  "saved_at": 1767982936.7021089
}
```

<img width="800" height="800" alt="cp_best_1" src="https://github.com/user-attachments/assets/4046fefa-a469-4f0d-9ab7-59504bdd5ffa" />
