### PR TITLE
Fix visualization with `-inf` scores

### DIFF
--- a/scripts/visualizer.py
+++ b/scripts/visualizer.py
@@ -1,9 +1,13 @@
+import math
 import os
 import json
 import glob
 import logging
 import shutil
 import re as _re
+from numbers import Number
+from typing import Optional, Any
+
 from flask import Flask, render_template, render_template_string, jsonify
 
 
@@ -60,6 +64,7 @@ def load_evolution_data(checkpoint_folder):
             if os.path.exists(prog_path):
                 with open(prog_path) as pf:
                     prog = json.load(pf)
+                    sanitize_program_for_visualization(prog)
                 prog["id"] = pid
                 prog["island"] = island_idx
                 nodes.append(prog)
@@ -80,6 +85,18 @@ def load_evolution_data(checkpoint_folder):
         "edges": edges,
         "checkpoint_dir": checkpoint_folder,
     }
+
+def sanitize_program_for_visualization(program: dict[str, Any]) -> None:
+    for k, v in program["metrics"].items():
+        if not check_json_float(v):
+            program["metrics"][k] = None
+        if "parent_metrics" in program["metadata"]:
+            for k, v in program["metadata"]["parent_metrics"].items():
+                if not check_json_float(v):
+                    program["metadata"]["parent_metrics"][k] = None
+
+def check_json_float(v: Optional[float]) -> bool:
+    return isinstance(v, Number) and not (math.isinf(v) or math.isnan(v))
 
 
 @app.route("/")


### PR DESCRIPTION
**Context**
For evolutions based on positive metrics to minimize (like a cost), we want to be able to assign a negative combined_score (=-cost) to programs and assign `-inf` to programs not running properly so that they are always ranked worse than others (especially if we do not now a bound on the cost). Note that if we do not assign any metrics to failing programs, the database will later return a fitness of 0 when requested (e.g. when ranking top programs) and thus see the failing program as an improved program (which is obviously not what we would like).
This works well during program evolution, but when using the (very nice) visualizer, loading data is failing.
More precisely the checkpoint is loaded in python code properly and then sent to the javascript via a `Response` object decoded with `resp.json()` in `fetchAndRender()` from "main.js".  This is crashing if it does not respect fully json specs (and NaN, Infinity are not json valid even though js objects).
<img width="1798" height="54" alt="image" src="https://github.com/user-attachments/assets/1b209872-94b8-452f-b110-dca8d50128e3" />


**Solution proposed**
In this PR, we replace `-inf`, `+inf`, and `nan` values in programs metrics by `None` before visualizing. Thanks to that:
- The data import does not crash anymore
- The failing programs are clustered in the `NaN` box in the "performance" tab which seems to be the proper way to visualize them.
<img width="2068" height="962" alt="image" src="https://github.com/user-attachments/assets/5dee6ae2-55cb-4135-a422-e5b92fc8e770" />

