### PR TITLE
fix(logging): fix logging bug in reject sampling

### DIFF
--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -1067,8 +1067,8 @@ class ProgramDatabase:
             other = self.programs[pid]
 
             if other.embedding is None:
-                logger.log(
-                    "Warning: Program %s has no embedding, skipping similarity check", other.id
+                logger.warning(
+                    f"Program {other.id} has no embedding, skipping similarity check"
                 )
                 continue
 


### PR DESCRIPTION
Hi developers,

@codelion , I found there might be logging misuse in the code snippet of reject sampling.

```
                logger.log(
                    "Warning: Program %s has no embedding, skipping similarity check", other.id
                )
```

should be changed with

```
                logger.warning(
                    f"Program {other.id} has no embedding, skipping similarity check"
                )
```