### PR TITLE
Show actual SEARCH/REPLACE content in diff summaries

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -78,9 +78,14 @@ prompt:
   # Feature extraction and program labeling thresholds
   # These control how the LLM perceives and categorizes programs
   suggest_simplification_after_chars: 500     # Suggest simplifying if program exceeds this many characters
-  include_changes_under_chars: 100           # Include change descriptions in features if under this length  
+  include_changes_under_chars: 100           # Include change descriptions in features if under this length
   concise_implementation_max_lines: 10        # Label as "concise" if program has this many lines or fewer
   comprehensive_implementation_min_lines: 50  # Label as "comprehensive" if program has this many lines or more
+
+  # Diff summary formatting for "Previous Attempts" section
+  # Controls how SEARCH/REPLACE blocks are displayed in prompts
+  diff_summary_max_line_len: 100              # Truncate lines longer than this (with "...")
+  diff_summary_max_lines: 30                  # Max lines per SEARCH/REPLACE block
 
   # Note: meta-prompting features are not yet implemented
 

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -281,6 +281,10 @@ class PromptConfig:
         50  # Label as "comprehensive" if program has this many lines or more
     )
 
+    # Diff summary formatting for "Previous Attempts" section
+    diff_summary_max_line_len: int = 100  # Truncate lines longer than this
+    diff_summary_max_lines: int = 30  # Max lines per SEARCH/REPLACE block
+
     # Backward compatibility - deprecated
     code_length_threshold: Optional[int] = (
         None  # Deprecated: use suggest_simplification_after_chars
@@ -340,7 +344,9 @@ class DatabaseConfig:
     artifact_size_threshold: int = 32 * 1024  # 32KB threshold
     cleanup_old_artifacts: bool = True
     artifact_retention_days: int = 30
-    max_snapshot_artifacts: Optional[int] = 100  # Max artifacts in worker snapshots (None=unlimited)
+    max_snapshot_artifacts: Optional[int] = (
+        100  # Max artifacts in worker snapshots (None=unlimited)
+    )
 
     novelty_llm: Optional["LLMInterface"] = None
     embedding_model: Optional[str] = None

--- a/tests/test_code_utils.py
+++ b/tests/test_code_utils.py
@@ -3,7 +3,13 @@ Tests for code utilities in openevolve.utils.code_utils
 """
 
 import unittest
-from openevolve.utils.code_utils import apply_diff, extract_diffs
+
+from openevolve.utils.code_utils import (
+    _format_block_lines,
+    apply_diff,
+    extract_diffs,
+    format_diff_summary,
+)
 
 
 class TestCodeUtils(unittest.TestCase):
@@ -87,6 +93,93 @@ class TestCodeUtils(unittest.TestCase):
             result,
             expected_code,
         )
+
+
+class TestFormatDiffSummary(unittest.TestCase):
+    """Tests for format_diff_summary showing actual diff content"""
+
+    def test_single_line_changes(self):
+        """Single-line changes should show inline format"""
+        diff_blocks = [("x = 1", "x = 2")]
+        result = format_diff_summary(diff_blocks)
+        self.assertEqual(result, "Change 1: 'x = 1' to 'x = 2'")
+
+    def test_multi_line_changes_show_actual_content(self):
+        """Multi-line changes should show actual SEARCH/REPLACE content"""
+        diff_blocks = [
+            (
+                "def old():\n    return False",
+                "def new():\n    return True",
+            )
+        ]
+        result = format_diff_summary(diff_blocks)
+        # Should contain actual code, not "2 lines"
+        self.assertIn("def old():", result)
+        self.assertIn("return False", result)
+        self.assertIn("def new():", result)
+        self.assertIn("return True", result)
+        self.assertIn("Replace:", result)
+        self.assertIn("with:", result)
+        # Should NOT contain generic line count
+        self.assertNotIn("2 lines", result)
+
+    def test_multiple_diff_blocks(self):
+        """Multiple diff blocks should be numbered"""
+        diff_blocks = [
+            ("a = 1", "a = 2"),
+            ("def foo():\n    pass", "def bar():\n    return 1"),
+        ]
+        result = format_diff_summary(diff_blocks)
+        self.assertIn("Change 1:", result)
+        self.assertIn("Change 2:", result)
+        self.assertIn("'a = 1' to 'a = 2'", result)
+        self.assertIn("def foo():", result)
+        self.assertIn("def bar():", result)
+
+    def test_configurable_max_line_len(self):
+        """max_line_len parameter should control line truncation"""
+        long_line = "x" * 50
+        # Must be multi-line to trigger block format (single-line uses inline format)
+        diff_blocks = [(long_line + "\nline2", "short\nline2")]
+        # With default (100), no truncation
+        result_default = format_diff_summary(diff_blocks)
+        self.assertNotIn("...", result_default)
+        # With max_line_len=30, should truncate the long line
+        result_short = format_diff_summary(diff_blocks, max_line_len=30)
+        self.assertIn("...", result_short)
+
+    def test_configurable_max_lines(self):
+        """max_lines parameter should control block truncation"""
+        many_lines = "\n".join([f"line{i}" for i in range(20)])
+        diff_blocks = [(many_lines, "replacement")]
+        # With max_lines=10, should truncate
+        result = format_diff_summary(diff_blocks, max_lines=10)
+        self.assertIn("... (10 more lines)", result)
+
+    def test_block_lines_basic_formatting(self):
+        """Lines should be indented with 2 spaces"""
+        lines = ["line1", "line2"]
+        result = _format_block_lines(lines)
+        self.assertEqual(result, "  line1\n  line2")
+
+    def test_block_lines_long_line_truncation(self):
+        """Lines over 100 chars should be truncated by default"""
+        long_line = "x" * 150
+        result = _format_block_lines([long_line])
+        self.assertIn("...", result)
+        self.assertLess(len(result.split("\n")[0]), 110)
+
+    def test_block_lines_many_lines_truncation(self):
+        """More than 30 lines should show truncation message by default"""
+        lines = [f"line{i}" for i in range(50)]
+        result = _format_block_lines(lines)
+        self.assertIn("... (20 more lines)", result)
+        self.assertEqual(len(result.split("\n")), 31)
+
+    def test_block_lines_empty_input(self):
+        """Empty input should return '(empty)'"""
+        result = _format_block_lines([])
+        self.assertEqual(result, "  (empty)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When diff-based evolution is enabled, the "Previous Attempts" section of prompts shows changes like:

    Change 1: Replace 15 lines with 18 lines

This gives the LLM no visibility into what the actual edits were, making it harder to:
- Learn from successful patterns
- Avoid repeating failed exact matches
- Understand what format produces valid SEARCH blocks

This contributes to the high rate of "apply diff fail" errors (see issue #346) where SEARCH patterns don't exactly match the original code.

## Solution

Update `format_diff_summary()` to show actual content for multi-line blocks:

    Change 1: Replace:
      def old_function():
          return False
    with:
      def new_function():
          return True

Single-line changes remain compact:

    Change 1: 'x = 1' to 'x = 2'

Add `_format_block_lines()` helper with configurable truncation limits.

## Configuration

New options in `prompt:` config section:

```yaml
prompt:
  diff_summary_max_line_len: 100  # Truncate lines longer than this
  diff_summary_max_lines: 30      # Max lines per SEARCH/REPLACE block
```

## Files Changed

- `openevolve/config.py` - Add PromptConfig options
- `openevolve/utils/code_utils.py` - Update format_diff_summary
- `openevolve/iteration.py` - Pass config to format_diff_summary
- `openevolve/process_parallel.py` - Pass config to format_diff_summary
- `tests/test_code_utils.py` - Add tests for new behavior

Some files got reformatted, I'll leave those changes there.