### PR TITLE
Fix retry storm problem in data fetching in visualizer 

### DIFF
--- a/scripts/static/js/main.js
+++ b/scripts/static/js/main.js
@@ -118,7 +118,12 @@ function loadAndRenderData(data) {
 if (window.STATIC_DATA) {
     loadAndRenderData(window.STATIC_DATA);
 } else {
+    let isFetching = false;
+    
     function fetchAndRender() {
+        if (isFetching) return; 
+        isFetching = true;
+        
         fetch('/api/data')
             .then(resp => resp.json())
             .then(data => {
@@ -128,6 +133,12 @@ if (window.STATIC_DATA) {
                 }
                 lastDataStr = dataStr;
                 loadAndRenderData(data);
+            })
+            .catch(err => {
+                console.error('Failed to fetch data:', err);
+            })
+            .finally(() => {
+                isFetching = false; 
             });
     }
     fetchAndRender();


### PR DESCRIPTION
This PR addresses an issue in the visualizer/main.js where multiple simultaneous data-fetching requests could be triggered if a previous request had not yet completed.

In scenarios with high latency, limited bandwidth, or large data payloads, the `fetchAndRender` function could overlap with the next scheduled interval. This led to a "retry storm" or request buildup, unnecessarily taxing the API causing UI to not be able to load the data or crash after some time. 

<img width="737" height="632" alt="Screenshot 2026-02-05 at 12 23 23 AM" src="https://github.com/user-attachments/assets/bc902ddd-e8f4-4cf5-931a-b4bff4209673" />
