### PR TITLE
Threshold-Elites Island-based Program Selection

### DIFF
--- a/examples/attention_optimization/config.yaml
+++ b/examples/attention_optimization/config.yaml
@@ -6,12 +6,12 @@ log_level: "INFO"
 # LLM configuration
 llm:
   # primary_model: "gemini-2.0-flash-lite"
-  primary_model: "gemini-3-flash-preview"
+  primary_model: "gemini-2.5-flash"
   # primary_model: "gpt-4.1-nano"
   # primary_model: "o3"
   primary_model_weight: 0.8
   # secondary_model: "gemini-2.0-flash"
-  secondary_model: "gemini-3-pro-preview"
+  secondary_model: "gemini-3-flash-preview"
   # secondary_model: "gpt-4.1-mini"
   secondary_model_weight: 0.2
   api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"

--- a/examples/attention_optimization/config.yaml
+++ b/examples/attention_optimization/config.yaml
@@ -6,13 +6,15 @@ log_level: "INFO"
 # LLM configuration
 llm:
   # primary_model: "gemini-2.0-flash-lite"
+  primary_model: "gemini-3-flash-preview"
   # primary_model: "gpt-4.1-nano"
-  primary_model: "o3"
+  # primary_model: "o3"
   primary_model_weight: 0.8
   # secondary_model: "gemini-2.0-flash"
-  secondary_model: "gpt-4.1-mini"
+  secondary_model: "gemini-3-pro-preview"
+  # secondary_model: "gpt-4.1-mini"
   secondary_model_weight: 0.2
-  # api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
+  api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
   # api_base: "https://api.cerebras.ai/v1"
   temperature: 0.7
   top_p: 0.95

--- a/examples/attention_optimization/evaluator.py
+++ b/examples/attention_optimization/evaluator.py
@@ -271,7 +271,7 @@ class MLIRAttentionEvaluator:
                 "compile_time": float(compile_time or 0),
                 "method": result.get('method', 'ir_analysis'),
                 "size_ratio": result.get('size_ratio', 1.0),
-                "optimization_score": result.get('optimization_score', 1.0)
+                "combined_score": result.get('combined_score', 1.0)
             }
             
             print(f"📊 Result: error={error:.3f}, speedup={speedup:.3f}x, runtime={runtime:.3f}")

--- a/examples/attention_optimization/evaluator.py
+++ b/examples/attention_optimization/evaluator.py
@@ -17,7 +17,11 @@ import re
 class MLIRAttentionEvaluator:
     def __init__(self):
         self.verify_tools()
-        self.mlir_file = Path("mlir/self_attn_with_consts_linalg_dialect.mlir")
+        # Get the absolute path of the current file
+        current_file_path = os.path.abspath(__file__)
+        # Get the directory containing the current file
+        current_dir = os.path.dirname(current_file_path)
+        self.mlir_file = Path(os.path.join(current_dir, "mlir/self_attn_with_consts_linalg_dialect.mlir"))
         # self.mlir_file = Path("mlir/export_mlir.mlir")
         self.baseline_mlir = None
         self.baseline_metrics = None
@@ -140,7 +144,7 @@ class MLIRAttentionEvaluator:
             'method': 'ir_analysis',
             'size_ratio': size_ratio,
             'ops_ratio': ops_ratio,
-            'optimization_score': base_speedup
+            'combined_score': base_speedup
         }
 
     def apply_optimizations(self, mlir_content, params):

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -351,6 +351,7 @@ class DatabaseConfig:
     novelty_llm: Optional["LLMInterface"] = None
     embedding_model: Optional[str] = None
     similarity_threshold: float = 0.99
+    variant: str = "threshold-elites"
 
 
 @dataclass

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -352,7 +352,7 @@ class DatabaseConfig:
     embedding_model: Optional[str] = None
     similarity_threshold: float = 0.99
     variant: str = "threshold-elites"
-
+    elite_threshold: int = 3
 
 @dataclass
 class EvaluatorConfig:

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -10,6 +10,7 @@ import random
 import shutil
 import time
 import uuid
+import math
 from dataclasses import asdict, dataclass, field, fields
 
 # FileLock removed - no longer needed with threaded parallel processing

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -403,7 +403,9 @@ class ProgramDatabase:
 
         # Calculate feature coordinates for Threshold-Elites
         embd = self._calculate_feature_coords(program)
+        score = get_fitness_score(program.metrics, self.config.feature_dimensions)
         program.embedding = embd
+        program.metrics["elite_score"] = score
 
         # Determine target island
         # If target_island is not specified and program has a parent, inherit parent's island
@@ -442,8 +444,8 @@ class ProgramDatabase:
             )
             return program.id  # Do not add non-novel program
 
-        score = program.metrics["combined_score"]
 
+        elite_threshold = getattr(self.config, "elite_threshold", 3)
         for pid in self.islands[island_idx]:
             other = self.programs[pid]
 
@@ -456,12 +458,12 @@ class ProgramDatabase:
             #similarity = self._cosine_similarity(embd, other.embedding)
             distance = math.sqrt(sum((a - b) ** 2 for a, b in zip(embd, other.embedding)))
 
-            if distance < 3: 
+            if distance < elite_threshold: 
                 # self._is_better(program, other)
-                if score > other.metrics["combined_score"]:
-                    other.metrics["combined_score"] = float("-inf")
+                if score > other.metrics["elite_score"]:
+                    other.metrics["elite_score"] = float("-inf")
                 else:
-                    program.metrics["combined_score"] = float("-inf")
+                    program.metrics["elite_score"] = float("-inf")
 
 
         # Add to island

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -209,7 +209,29 @@ class ProgramDatabase:
         self.similarity_threshold = config.similarity_threshold
 
     def add(
-        self, program: Program, iteration: int = None, target_island: Optional[int] = None
+        self, program: Program, iteration: int = None, target_island: Optional[int] = None, 
+    ) -> str:
+        """
+        Add a program to the database
+
+        Args:
+            program: Program to add
+            iteration: Current iteration (defaults to last_iteration)
+            target_island: Specific island to add to (auto-detects parent's island if None)
+
+        Returns:
+            Program ID
+        """
+        variant = getattr(self.config, "variant", "map-elites")
+        if variant == "map-elites":
+            self.add_map_elites_program(program, iteration, target_island)
+        elif variant == "threshold-elites":
+            self.add_threshold_elites_program(program, iteration, target_island)
+        else:
+            raise NotImplementedError()
+
+    def add_map_elites_program(
+        self, program: Program, iteration: int = None, target_island: Optional[int] = None, 
     ) -> str:
         """
         Add a program to the database
@@ -339,6 +361,108 @@ class ProgramDatabase:
                 self.islands[island_idx].discard(existing_program_id)
 
             island_feature_map[feature_key] = program.id
+
+        # Add to island
+        self.islands[island_idx].add(program.id)
+
+        # Track which island this program belongs to
+        program.metadata["island"] = island_idx
+
+        # Update archive
+        self._update_archive(program)
+
+        # Enforce population size limit BEFORE updating best program tracking
+        # This ensures newly added programs aren't immediately removed
+        self._enforce_population_limit(exclude_program_id=program.id)
+
+        # Update the absolute best program tracking (after population enforcement)
+        self._update_best_program(program)
+
+        # Update island-specific best program tracking
+        self._update_island_best_program(program, island_idx)
+
+        # Save to disk if configured
+        if self.config.db_path:
+            self._save_program(program)
+
+        logger.debug(f"Added program {program.id} to island {island_idx}")
+
+        return program.id
+
+    def add_threshold_elites_program(
+        self, program: Program, iteration: int = None, target_island: Optional[int] = None, 
+    ) -> str:
+        # Store the program
+        # If iteration is provided, update the program's iteration_found
+        if iteration is not None:
+            program.iteration_found = iteration
+            # Update last_iteration if needed
+            self.last_iteration = max(self.last_iteration, iteration)
+
+        self.programs[program.id] = program
+
+        # Calculate feature coordinates for Threshold-Elites
+        embd = self._calculate_feature_coords(program)
+        program.embedding = embd
+
+        # Determine target island
+        # If target_island is not specified and program has a parent, inherit parent's island
+        if target_island is None and program.parent_id:
+            parent = self.programs.get(program.parent_id)
+            if parent and "island" in parent.metadata:
+                # Child inherits parent's island to maintain island isolation
+                island_idx = parent.metadata["island"]
+                logger.debug(
+                    f"Program {program.id} inheriting island {island_idx} from parent {program.parent_id}"
+                )
+            else:
+                # Parent not found or has no island, use current_island
+                island_idx = self.current_island
+                if parent:
+                    logger.warning(
+                        f"Parent {program.parent_id} has no island metadata, using current_island {island_idx}"
+                    )
+                else:
+                    logger.warning(
+                        f"Parent {program.parent_id} not found, using current_island {island_idx}"
+                    )
+        elif target_island is not None:
+            # Explicit target island specified (e.g., for migrants)
+            island_idx = target_island
+        else:
+            # No parent and no target specified, use current island
+            island_idx = self.current_island
+
+        island_idx = island_idx % len(self.islands)  # Ensure valid island
+
+        # Novelty check before adding
+        if not self._is_novel(program.id, island_idx):
+            logger.debug(
+                f"Program {program.id} failed in novelty check and won't be added in the island {island_idx}"
+            )
+            return program.id  # Do not add non-novel program
+
+        score = program.metrics["combined_score"]
+
+        for pid in self.islands[island_idx]:
+            other = self.programs[pid]
+
+            if other.embedding is None:
+                logger.warning(
+                    f"Warning: Program {other.id} has no embedding, skipping similarity check"
+                )
+                continue
+
+            #similarity = self._cosine_similarity(embd, other.embedding)
+            distance = math.sqrt(sum((a - b) ** 2 for a, b in zip(embd, other.embedding)))
+
+            if distance < 3: 
+                # self._is_better(program, other)
+                if score > other.metrics["combined_score"]:
+                    other.metrics["combined_score"] = float("-inf")
+                else:
+                    program.metrics["combined_score"] = float("-inf")
+
 
         # Add to island
         self.islands[island_idx].add(program.id)

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -11,6 +11,7 @@ import shutil
 import time
 import uuid
 import math
+import copy
 from dataclasses import asdict, dataclass, field, fields
 
 # FileLock removed - no longer needed with threaded parallel processing
@@ -1440,6 +1441,7 @@ class ProgramDatabase:
                     metadata={"island": self.current_island},
                     artifacts_json=best_program.artifacts_json,
                     artifact_dir=best_program.artifact_dir,
+                    embedding=copy.deepcopy(best_program.embedding)
                 )
                 self.programs[copy_program.id] = copy_program
                 self.islands[self.current_island].add(copy_program.id)
@@ -1486,6 +1488,7 @@ class ProgramDatabase:
                     metadata={"island": self.current_island},
                     artifacts_json=best_program.artifacts_json,
                     artifact_dir=best_program.artifact_dir,
+                    embedding=copy.deepcopy(best_program.embedding)
                 )
                 self.programs[copy_program.id] = copy_program
                 self.islands[self.current_island].add(copy_program.id)


### PR DESCRIPTION
## Net effect (what changes for users)

* You can now choose between map-elites and threshold-elites archive insertion using DatabaseConfig.variant.

  * In threshold-elites, programs are:

  * filtered by novelty,

  * grouped into islands (with parent island inheritance),

* and locally compared by embedding distance with a winner-takes-all rule inside a threshold radius.

* The attention optimization evaluator becomes more portable (pathing) and its output schema shifts toward a combined_score field.

## openevolve/database.py

This is the main functional change: introduces a “threshold-elites” variant alongside map-elites, and refactors add() accordingly.

### Variant-based dispatch in add(...)

* Database.add(...) now checks config.variant:

  * "map-elites" → add_map_elites_program(...)

  * "threshold-elites" → add_threshold_elites_program(...)

  * otherwise raises NotImplementedError.

### New add_threshold_elites_program(...) behavior

When adding a program:

* Stores program + iteration bookkeeping

  * Updates program.iteration_found and self.last_iteration.

* Computes embedding + an elite score

  * Calls _calculate_feature_coords(program) and stores in program.embedding.

  * Computes a fitness-based score = get_fitness_score(...).

  * Stores program.metrics["elite_score"] = score.

* Determines island placement

  * If target_island is not given and the program has a parent, it inherits the parent’s island from parent.metadata["island"] to keep island isolation.

  * Else falls back to self.current_island.

* Novelty gating happens before insertion

  * If _is_novel(...) fails, the program is not added to the island.

* Threshold-elites competition (within an island)

  * For existing programs in the island, computes Euclidean distance between embeddings.

  * If distance < elite_threshold, it keeps the higher elite_score and demotes the other by setting its elite_score to -inf (effectively marking it as dominated).

* Finalization

  * Adds the program to the island, sets program.metadata["island"], updates archive/best tracking, enforces population limit, and optionally saves to disk.

### Exploration parent sampling now preserves embeddings

* In two places inside _sample_exploration_parent(...), when cloning the best program, it now does:

  * embedding=copy.deepcopy(best_program.embedding)

* This prevents the clone from sharing the same embedding object reference.

### Misc

* copy, math, asdict/fields imports added (supporting new logic).


## openevolve/config.py

* Extends DatabaseConfig with parameters to support a new archive strategy:

  * variant: str = "threshold-elites" (strategy selector)

  * elite_threshold: int = 3 (distance threshold used by the new strategy)


## examples/attention_optimization/evaluator.py

* Makes MLIR path resolution robust:

  * Previously: Path("mlir/self_attn_with_consts_linalg_dialect.mlir") (relative to current working directory).

  * Now: builds an absolute path relative to the evaluator file’s directory using __file__. This prevents failures when running from a different working directory.

* Renames/standardizes a scoring field:

  * In estimate_performance_from_ir(...), the returned dict changes from using optimization_score to combined_score.

  * In evaluate(...), result packaging similarly switches from optimization_score → combined_score.

