### PR TITLE
Introducing a "threshold-elites" variant alongside map-elites

### DIFF
--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -351,7 +351,8 @@ class DatabaseConfig:
     novelty_llm: Optional["LLMInterface"] = None
     embedding_model: Optional[str] = None
     similarity_threshold: float = 0.99
-
+    variant: str = "map-elites"  # Parameters to support a new Quality-Diversity variant
+    elite_threshold: int = 3  # Distance threshold used by the threshold-elites variant
 
 @dataclass
 class EvaluatorConfig:

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -226,9 +226,9 @@ class ProgramDatabase:
         """
         variant = getattr(self.config, "variant", "map-elites")
         if variant == "map-elites":
-            self.add_map_elites_program(program, iteration, target_island)
+            return self.add_map_elites_program(program, iteration, target_island)
         elif variant == "threshold-elites":
-            self.add_threshold_elites_program(program, iteration, target_island)
+            return self.add_threshold_elites_program(program, iteration, target_island)
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
## Net effect (what changes for users)

* You can now choose between map-elites and threshold-elites using DatabaseConfig.variant.

* In threshold-elites, programs are:

  * filtered by novelty,

  * grouped into islands (with parent island inheritance),

  * and locally compared by embedding distance with a winner-takes-all rule inside a threshold radius.



## openevolve/database.py

This is the main functional change: introduces a “threshold-elites” variant alongside map-elites, and refactors add() accordingly.

### Variant-based dispatch in add(...)

* Database.add(...) now checks config.variant:

  * "map-elites" → add_map_elites_program(...)

  * "threshold-elites" → add_threshold_elites_program(...)

  * otherwise raises NotImplementedError.

### New add_threshold_elites_program(...) behavior

When adding a program:

* Stores program + iteration bookkeeping

  * Updates program.iteration_found and self.last_iteration.

* Computes embedding + an elite score

  * Calls _calculate_feature_coords(program) and stores in program.embedding.

  * Computes a fitness-based score = get_fitness_score(...).

  * Stores program.metrics["elite_score"] = score.

* Determines island placement

  * If target_island is not given and the program has a parent, it inherits the parent’s island from parent.metadata["island"] to keep island isolation.

  * Else falls back to self.current_island.

* Novelty gating happens before insertion

  * If _is_novel(...) fails, the program is not added to the island.

* Threshold-elites competition (within an island)

  * For existing programs in the island, computes Euclidean distance between embeddings.

  * If distance < elite_threshold, it keeps the higher elite_score and demotes the other by setting its elite_score to -inf (effectively marking it as dominated).

* Finalization

  * Adds the program to the island, sets program.metadata["island"], updates archive/best tracking, enforces population limit, and optionally saves to disk.

### Exploration parent sampling now preserves embeddings

* In two places inside _sample_exploration_parent(...), when cloning the best program, it now does:

  * embedding=copy.deepcopy(best_program.embedding)

* This prevents the clone from sharing the same embedding object reference.

### Misc

* copy, math imports added (supporting new logic).


## openevolve/config.py

* Extends DatabaseConfig with parameters to support a Quality-Diversity variant:

  * variant: str = "map-elites" (variant selector)

  * elite_threshold: int = 3 (distance threshold used by the threshold-elites variant)
