### PR TITLE
Repair Sub-Agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,14 @@ python scripts/visualizer.py --path examples/function_minimization/openevolve_ou
 
 5. **Iteration (`openevolve/iteration.py`)**: Worker process that samples from islands, generates mutations via LLM, evaluates programs, and stores artifacts.
 
+6. **Repair Subagent (`openevolve/evaluator.py`)**: When an evaluator raises `EvaluatorRepairRequest` (e.g. on compilation failure), the evaluator asks a dedicated LLM ensemble to fix the code and re-evaluates it. Configured via `EvaluatorConfig.repair_on_failure`, `max_repair_attempts`, and `repair_diff_based`. Uses `repair_models` from `LLMConfig` (falls back to `evaluator_models` then `models`). Repair history is stored as artifacts.
+
 ### Key Architectural Patterns
 
 - **Island-Based Evolution**: Multiple populations evolve separately with periodic migration
 - **MAP-Elites**: Maintains diversity by mapping programs to feature grid cells
 - **Artifact System**: Side-channel for programs to return debugging data, stored as JSON or files
+- **LLM Repair Loop**: Evaluators can raise `EvaluatorRepairRequest` to trigger LLM-based code repair before discarding broken programs
 - **Process Worker Pattern**: Each iteration runs in fresh process with database snapshot
 - **Double-Selection**: Programs for inspiration differ from those shown to LLM
 - **Lazy Migration**: Islands migrate based on generation counts, not iterations

--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ evaluator:
   enable_artifacts: true      # Error feedback to LLM
   cascade_evaluation: true    # Multi-stage testing
   use_llm_feedback: true      # AI code quality assessment
+  repair_on_failure: true     # LLM repair on EvaluatorRepairRequest
+  max_repair_attempts: 2      # Retry limit per broken program
+  repair_diff_based: false    # true=SEARCH/REPLACE diffs, false=full rewrite
 
 prompt:
   # Sophisticated inspiration system
@@ -719,6 +722,44 @@ return EvaluationResult(
 ```
 
 This creates a **feedback loop** where each generation learns from previous mistakes!
+
+### LLM-Based Code Repair
+
+When evolved code has a correctable error (e.g. a compilation failure), your evaluator can raise `EvaluatorRepairRequest` to trigger an automatic LLM repair attempt instead of discarding the program:
+
+```python
+from openevolve.evaluation_result import EvaluatorRepairRequest
+
+def evaluate(program_path):
+    result = compile(program_path)
+    if result.returncode != 0:
+        with open(program_path) as f:
+            code = f.read()
+        raise EvaluatorRepairRequest(
+            message="Compilation failed",
+            broken_code=code,
+            repair_context=result.stderr,
+            language="cpp",
+            fallback_metrics={"combined_score": 0.0},  # used if repair fails
+        )
+    # ... normal evaluation ...
+```
+
+Enable repair in your config:
+
+```yaml
+evaluator:
+  repair_on_failure: true
+  max_repair_attempts: 2
+  repair_diff_based: false  # true for SEARCH/REPLACE diffs, false for full rewrite
+
+llm:
+  repair_models:  # optional — falls back to evaluator_models, then models
+    - name: "your-repair-model"
+      weight: 1.0
+```
+
+Repair history is stored in program artifacts and displayed in the visualizer.
 
 ## Visualization
 

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -402,8 +402,6 @@ class EvaluatorConfig:
     # True  → ask the LLM for SEARCH/REPLACE diffs (uses repair_diff_user template)
     # False → ask the LLM for a full rewrite     (uses repair_full_rewrite_user template)
     repair_diff_based: bool = False
-    # Diff pattern used when repair_diff_based=True; must match the template.
-    repair_diff_pattern: str = r"<<<<<<< SEARCH\n(.*?)=======\n(.*?)>>>>>>> REPLACE"
 
 
 @dataclass

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -109,8 +109,12 @@ class LLMConfig(LLMModelConfig):
     # n-model configuration for evolution LLM ensemble
     models: List[LLMModelConfig] = field(default_factory=list)
 
-    # n-model configuration for evaluator LLM ensemble
+    # n-model configuration for evaluator LLM ensemble (LLM feedback scoring)
     evaluator_models: List[LLMModelConfig] = field(default_factory=lambda: [])
+
+    # n-model configuration for repair LLM ensemble.
+    # Falls back to evaluator_models (then models) when not set.
+    repair_models: List[LLMModelConfig] = field(default_factory=lambda: [])
 
     # Backwardes compatibility with primary_model(_weight) options
     primary_model: str = None
@@ -184,7 +188,7 @@ class LLMConfig(LLMModelConfig):
 
     def update_model_params(self, args: Dict[str, Any], overwrite: bool = False) -> None:
         """Update model parameters for all models"""
-        for model in self.models + self.evaluator_models:
+        for model in self.models + self.evaluator_models + self.repair_models:
             for key, value in args.items():
                 if overwrite or getattr(model, key, None) is None:
                     setattr(model, key, value)
@@ -194,6 +198,7 @@ class LLMConfig(LLMModelConfig):
         # Clear existing models lists
         self.models = []
         self.evaluator_models = []
+        self.repair_models = []
 
         # Re-run model generation logic from __post_init__
         if self.primary_model:
@@ -219,6 +224,10 @@ class LLMConfig(LLMModelConfig):
         # If no evaluator models are defined, use the same models as for evolution
         if not self.evaluator_models:
             self.evaluator_models = self.models.copy()
+
+        # If no repair models are defined, fall back to evaluator_models
+        if not self.repair_models:
+            self.repair_models = self.evaluator_models.copy()
 
         # Update models with shared configuration values
         shared_config = {
@@ -382,6 +391,19 @@ class EvaluatorConfig:
     # Artifact handling
     enable_artifacts: bool = True
     max_artifact_storage: int = 100 * 1024 * 1024  # 100MB per program
+
+    # LLM-based repair on EvaluatorRepairRequest
+    # When a user evaluator raises EvaluatorRepairRequest (e.g. on compile
+    # failure) OpenEvolve will ask the LLM to fix the code and re-evaluate,
+    # storing the repaired version in the database rather than the broken
+    # original.
+    repair_on_failure: bool = False
+    max_repair_attempts: int = 2
+    # True  → ask the LLM for SEARCH/REPLACE diffs (uses repair_diff_user template)
+    # False → ask the LLM for a full rewrite     (uses repair_full_rewrite_user template)
+    repair_diff_based: bool = False
+    # Diff pattern used when repair_diff_based=True; must match the template.
+    repair_diff_pattern: str = r"<<<<<<< SEARCH\n(.*?)=======\n(.*?)>>>>>>> REPLACE"
 
 
 @dataclass

--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -112,6 +112,9 @@ class OpenEvolve:
             for model_cfg in self.config.llm.evaluator_models:
                 if not hasattr(model_cfg, "random_seed") or model_cfg.random_seed is None:
                     model_cfg.random_seed = llm_seed
+            for model_cfg in self.config.llm.repair_models:
+                if not hasattr(model_cfg, "random_seed") or model_cfg.random_seed is None:
+                    model_cfg.random_seed = llm_seed
 
             logger.info(f"Set random seed to {self.config.random_seed} for reproducibility")
             logger.debug(f"Generated LLM seed: {llm_seed}")
@@ -139,6 +142,7 @@ class OpenEvolve:
         # Initialize components
         self.llm_ensemble = LLMEnsemble(self.config.llm.models)
         self.llm_evaluator_ensemble = LLMEnsemble(self.config.llm.evaluator_models)
+        self.llm_repair_ensemble = LLMEnsemble(self.config.llm.repair_models)
 
         self.prompt_sampler = PromptSampler(self.config.prompt)
         self.evaluator_prompt_sampler = PromptSampler(self.config.prompt)
@@ -158,6 +162,7 @@ class OpenEvolve:
             self.evaluator_prompt_sampler,
             database=self.database,
             suffix=Path(self.initial_program_path).suffix,
+            repair_llm_ensemble=self.llm_repair_ensemble,
         )
         self.evaluation_file = evaluation_file
 

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -1435,7 +1435,7 @@ class ProgramDatabase:
             Parent program selected using fitness-weighted sampling
         """
         island_id = island_id % len(self.islands)
-        island_programs = list(self.islands[island_id])
+        island_programs = sorted(self.islands[island_id])
 
         if not island_programs:
             # Island is empty, fall back to any available program

--- a/openevolve/evaluation_result.py
+++ b/openevolve/evaluation_result.py
@@ -7,6 +7,43 @@ from dataclasses import dataclass, field
 from typing import Dict, Union
 
 
+class EvaluatorRepairRequest(Exception):
+    """
+    Raised by a user evaluator to request an LLM-based code repair attempt.
+
+    Raise this instead of returning a zero score when the generated code has a
+    correctable error (e.g. a compilation failure).  OpenEvolve will attempt to
+    repair the code using the configured LLM before recording it in the database,
+    so that future evolution branches from working code rather than the broken
+    original.
+
+    Args:
+        message:        Human-readable error description (shown in repair history
+                        and logged).
+        broken_code:    The full source that failed.  Must be the complete file,
+                        not just the error region, so the repair LLM has full
+                        context.
+        repair_context: Optional extra information for the repair prompt (e.g.
+                        full compiler stderr, runtime traceback).  Defaults to
+                        the same text as *message*.
+        language:       Source-language identifier used in the prompt code fence
+                        (e.g. ``"cpp"``, ``"python"``).  Defaults to
+                        ``"python"``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        broken_code: str,
+        repair_context: str = "",
+        language: str = "python",
+    ) -> None:
+        super().__init__(message)
+        self.broken_code = broken_code
+        self.repair_context = repair_context or message
+        self.language = language
+
+
 @dataclass
 class EvaluationResult:
     """

--- a/openevolve/evaluation_result.py
+++ b/openevolve/evaluation_result.py
@@ -4,7 +4,7 @@ Evaluation result structures for OpenEvolve
 
 import json
 from dataclasses import dataclass, field
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 
 class EvaluatorRepairRequest(Exception):
@@ -18,17 +18,23 @@ class EvaluatorRepairRequest(Exception):
     original.
 
     Args:
-        message:        Human-readable error description (shown in repair history
-                        and logged).
-        broken_code:    The full source that failed.  Must be the complete file,
-                        not just the error region, so the repair LLM has full
-                        context.
-        repair_context: Optional extra information for the repair prompt (e.g.
-                        full compiler stderr, runtime traceback).  Defaults to
-                        the same text as *message*.
-        language:       Source-language identifier used in the prompt code fence
-                        (e.g. ``"cpp"``, ``"python"``).  Defaults to
-                        ``"python"``.
+        message:          Human-readable error description (shown in repair history
+                          and logged).
+        broken_code:      The full source that failed.  Must be the complete file,
+                          not just the error region, so the repair LLM has full
+                          context.
+        repair_context:   Optional extra information for the repair prompt (e.g.
+                          full compiler stderr, runtime traceback).  Defaults to
+                          the same text as *message*.
+        language:         Source-language identifier used in the prompt code fence
+                          (e.g. ``"cpp"``, ``"python"``).  Defaults to
+                          ``"python"``.
+        fallback_metrics: Metrics dict to use if repair is disabled or all repair
+                          attempts are exhausted.  Should include all feature
+                          dimensions required by the MAP-Elites database set to
+                          appropriate penalty values, plus ``combined_score: 0.0``.
+                          When ``None``, a minimal ``{"combined_score": 0.0}`` is
+                          used.
     """
 
     def __init__(
@@ -37,11 +43,13 @@ class EvaluatorRepairRequest(Exception):
         broken_code: str,
         repair_context: str = "",
         language: str = "python",
+        fallback_metrics: Optional[Dict[str, float]] = None,
     ) -> None:
         super().__init__(message)
         self.broken_code = broken_code
         self.repair_context = repair_context or message
         self.language = language
+        self.fallback_metrics: Dict[str, float] = fallback_metrics or {"combined_score": 0.0}
 
 
 @dataclass

--- a/openevolve/evaluator.py
+++ b/openevolve/evaluator.py
@@ -577,7 +577,7 @@ class Evaluator:
         # --- Parse the LLM response ---
         if self.config.repair_diff_based:
             from openevolve.utils.code_utils import apply_diff
-            repaired = apply_diff(broken_code, llm_response, self.config.repair_diff_pattern)
+            repaired = apply_diff(broken_code, llm_response)
         else:
             from openevolve.utils.code_utils import parse_full_rewrite
             repaired = parse_full_rewrite(llm_response, language)

--- a/openevolve/evaluator.py
+++ b/openevolve/evaluator.py
@@ -19,7 +19,7 @@ import traceback
 
 from openevolve.config import EvaluatorConfig
 from openevolve.database import ProgramDatabase
-from openevolve.evaluation_result import EvaluationResult
+from openevolve.evaluation_result import EvaluationResult, EvaluatorRepairRequest
 from openevolve.database import ProgramDatabase
 from openevolve.llm.ensemble import LLMEnsemble
 from openevolve.utils.async_utils import TaskPool, run_in_executor
@@ -45,11 +45,15 @@ class Evaluator:
         prompt_sampler: Optional[PromptSampler] = None,
         database: Optional[ProgramDatabase] = None,
         suffix: Optional[str] = ".py",
+        repair_llm_ensemble: Optional[LLMEnsemble] = None,
     ):
         self.config = config
         self.evaluation_file = evaluation_file
         self.program_suffix = suffix
         self.llm_ensemble = llm_ensemble
+        # Separate ensemble for LLM-based code repair; falls back to the main
+        # evaluator ensemble (llm_ensemble) when not provided.
+        self.repair_llm_ensemble = repair_llm_ensemble or llm_ensemble
         self.prompt_sampler = prompt_sampler
         self.database = database
 
@@ -61,6 +65,11 @@ class Evaluator:
 
         # Pending artifacts storage for programs
         self._pending_artifacts: Dict[str, Dict[str, Union[str, bytes]]] = {}
+
+        # Pending repairs: program_id → repaired source code.
+        # Populated by _attempt_repair when repair succeeds; consumed by
+        # iteration.py / process_parallel.py via get_pending_repair().
+        self._pending_repairs: Dict[str, str] = {}
 
         logger.info(f"Initialized evaluator with {evaluation_file}")
 
@@ -264,6 +273,28 @@ class Evaluator:
 
                 return {"error": 0.0, "timeout": True}
 
+            except EvaluatorRepairRequest as repair_req:
+                # The user evaluator signalled that the code needs LLM repair
+                # (e.g. a compilation failure).  Attempt repair if configured;
+                # otherwise fall through to the standard zero-score path.
+                if self.config.repair_on_failure and self.llm_ensemble:
+                    repaired_metrics = await self._attempt_repair(repair_req, program_id)
+                    if repaired_metrics is not None:
+                        return repaired_metrics
+                # Repair disabled, not configured, or all attempts exhausted.
+                logger.warning(
+                    f"Repair {'failed' if self.config.repair_on_failure else 'disabled'} "
+                    f"for program{program_id_str}: {repair_req}"
+                )
+                if artifacts_enabled and program_id:
+                    if program_id not in self._pending_artifacts:
+                        self._pending_artifacts[program_id] = {}
+                    self._pending_artifacts[program_id].update({
+                        "compile_error": str(repair_req),
+                        "repair_context": repair_req.repair_context,
+                    })
+                return {"combined_score": 0.0, "error": 0.0}
+
             except Exception as e:
                 last_exception = e
                 logger.warning(
@@ -327,6 +358,235 @@ class Evaluator:
             Artifacts dictionary or None if not found
         """
         return self._pending_artifacts.pop(program_id, None)
+
+    def get_pending_repair(self, program_id: str) -> Optional[str]:
+        """
+        Get and clear the repaired source code for a program, if one exists.
+
+        Returns the repaired code string when a previous ``_attempt_repair``
+        call succeeded, or ``None`` when no repair was performed.  The entry is
+        removed from the internal store on first read (one-shot).
+
+        Args:
+            program_id: Program ID used during evaluation.
+
+        Returns:
+            Repaired source code string, or ``None``.
+        """
+        return self._pending_repairs.pop(program_id, None)
+
+    async def _attempt_repair(
+        self,
+        repair_req: EvaluatorRepairRequest,
+        program_id: str,
+    ) -> Optional[Dict[str, float]]:
+        """
+        Attempt to repair broken code via the LLM, then re-evaluate.
+
+        Loops up to ``config.max_repair_attempts`` times.  On success the
+        repaired code is stored in ``_pending_repairs[program_id]`` and the
+        repair history is added to ``_pending_artifacts[program_id]`` so that
+        ``iteration.py`` can move both into ``Program.metadata``.
+
+        Args:
+            repair_req: The ``EvaluatorRepairRequest`` raised by the evaluator.
+            program_id: Program ID for artifact/repair storage.
+
+        Returns:
+            Metrics dict from the successfully repaired evaluation, or ``None``
+            if all repair attempts failed.
+        """
+        artifacts_enabled = os.environ.get("ENABLE_ARTIFACTS", "true").lower() == "true"
+        broken_code = repair_req.broken_code
+        error_message = str(repair_req)
+        repair_context = repair_req.repair_context
+        language = repair_req.language
+        repair_history: List[Dict] = []
+
+        for attempt in range(1, self.config.max_repair_attempts + 1):
+            logger.info(
+                f"Repair attempt {attempt}/{self.config.max_repair_attempts} "
+                f"for program {program_id} (language={language})"
+            )
+
+            repaired_code = await self._repair_code(
+                broken_code=broken_code,
+                error_message=error_message,
+                repair_context=repair_context,
+                language=language,
+            )
+            if repaired_code is None:
+                logger.warning(f"Repair attempt {attempt}: LLM returned no parseable code")
+                repair_history.append({
+                    "attempt": attempt,
+                    "error": error_message,
+                    "repair_error": "LLM returned no parseable code",
+                    "succeeded": False,
+                })
+                break
+
+            # Write the repaired code to a temp file and re-evaluate
+            with tempfile.NamedTemporaryFile(
+                suffix=self.program_suffix, delete=False
+            ) as tmp:
+                tmp.write(repaired_code.encode("utf-8"))
+                tmp_path = tmp.name
+
+            try:
+                result = await self._direct_evaluate(tmp_path)
+                eval_result = self._process_evaluation_result(result)
+
+                # Success — store the repaired code and history
+                repair_history.append({
+                    "attempt": attempt,
+                    "error": None,
+                    "succeeded": True,
+                })
+                logger.info(
+                    f"Repair succeeded on attempt {attempt} for program {program_id}"
+                )
+                self._pending_repairs[program_id] = repaired_code
+                if artifacts_enabled and program_id:
+                    if program_id not in self._pending_artifacts:
+                        self._pending_artifacts[program_id] = {}
+                    self._pending_artifacts[program_id]["repair_history"] = repair_history
+                    if eval_result.has_artifacts():
+                        self._pending_artifacts[program_id].update(eval_result.artifacts)
+
+                elapsed = 0.0  # timing already handled by outer evaluate_program
+                logger.info(
+                    f"Repaired program {program_id}: "
+                    f"{format_metrics_safe(eval_result.metrics)}"
+                )
+                return eval_result.metrics
+
+            except EvaluatorRepairRequest as next_req:
+                # Re-evaluation raised another repair request — prepare next loop
+                error_message = str(next_req)
+                repair_context = next_req.repair_context
+                broken_code = next_req.broken_code
+                repair_history.append({
+                    "attempt": attempt,
+                    "error": error_message,
+                    "succeeded": False,
+                })
+            except Exception as exc:
+                error_message = str(exc)
+                repair_history.append({
+                    "attempt": attempt,
+                    "error": error_message,
+                    "succeeded": False,
+                })
+                logger.warning(f"Repair attempt {attempt} raised exception: {exc}")
+                break
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        # All attempts exhausted
+        logger.warning(
+            f"All {self.config.max_repair_attempts} repair attempt(s) failed "
+            f"for program {program_id}"
+        )
+        if artifacts_enabled and program_id:
+            if program_id not in self._pending_artifacts:
+                self._pending_artifacts[program_id] = {}
+            self._pending_artifacts[program_id].update({
+                "compile_error": str(repair_req),
+                "repair_context": repair_req.repair_context,
+                "repair_history": repair_history,
+                "repair_failed": True,
+            })
+        return None
+
+    async def _repair_code(
+        self,
+        broken_code: str,
+        error_message: str,
+        repair_context: str,
+        language: str,
+    ) -> Optional[str]:
+        """
+        Ask the LLM to repair broken code and return the fixed source.
+
+        Uses the ``repair_full_rewrite_user`` or ``repair_diff_user`` template
+        (depending on ``config.repair_diff_based``) and the ``repair_system_message``
+        template (falling back to ``system_message`` if absent).
+
+        Returns the repaired code string on success, or ``None`` if the LLM
+        response could not be parsed.
+        """
+        if not self.repair_llm_ensemble or not self.prompt_sampler:
+            logger.warning("_repair_code called but repair_llm_ensemble or prompt_sampler is None")
+            return None
+
+        # --- Choose templates ---
+        user_template_name = (
+            "repair_diff_user" if self.config.repair_diff_based else "repair_full_rewrite_user"
+        )
+        try:
+            user_template = self.prompt_sampler.template_manager.get_template(user_template_name)
+        except ValueError:
+            logger.warning(
+                f"Repair template '{user_template_name}' not found — repair skipped. "
+                "Ensure the template file exists in your prompts directory."
+            )
+            return None
+
+        # Prefer a dedicated repair system message; fall back to the evolution one.
+        try:
+            system_message = self.prompt_sampler.template_manager.get_template(
+                "repair_system_message"
+            )
+        except ValueError:
+            try:
+                system_message = self.prompt_sampler.template_manager.get_template(
+                    "system_message"
+                )
+            except ValueError:
+                system_message = (
+                    "You are an expert software developer. "
+                    "Fix all errors in the provided code."
+                )
+
+        try:
+            # Use sequential replacement instead of str.format() so that braces
+            # inside broken_code / error_message / repair_context (e.g. C++ code)
+            # do not raise KeyError or corrupt the template.
+            user_message = user_template
+            for placeholder, value in [
+                ("{language}", language),
+                ("{error_message}", error_message),
+                ("{repair_context}", repair_context),
+                ("{broken_code}", broken_code),
+            ]:
+                user_message = user_message.replace(placeholder, value)
+        except Exception as exc:
+            logger.warning(f"Repair template substitution error: {exc}")
+            return None
+
+        try:
+            llm_response = await self.repair_llm_ensemble.generate_with_context(
+                system_message=system_message,
+                messages=[{"role": "user", "content": user_message}],
+            )
+        except Exception as exc:
+            logger.warning(f"LLM call during repair failed: {exc}")
+            return None
+
+        # --- Parse the LLM response ---
+        if self.config.repair_diff_based:
+            from openevolve.utils.code_utils import apply_diff
+            repaired = apply_diff(broken_code, llm_response, self.config.repair_diff_pattern)
+        else:
+            from openevolve.utils.code_utils import parse_full_rewrite
+            repaired = parse_full_rewrite(llm_response, language)
+
+        if not repaired or not repaired.strip():
+            logger.warning("Repair LLM response yielded empty code after parsing")
+            return None
+
+        return repaired
 
     async def _direct_evaluate(
         self, program_path: str

--- a/openevolve/evaluator.py
+++ b/openevolve/evaluator.py
@@ -293,7 +293,7 @@ class Evaluator:
                         "compile_error": str(repair_req),
                         "repair_context": repair_req.repair_context,
                     })
-                return {"combined_score": 0.0, "error": 0.0}
+                return repair_req.fallback_metrics
 
             except Exception as e:
                 last_exception = e

--- a/openevolve/evolution_trace.py
+++ b/openevolve/evolution_trace.py
@@ -102,6 +102,9 @@ class EvolutionTracer:
             "total_improvement": {},
             "best_improvement": {},
             "worst_decline": {},
+            # Repair stats: how often LLM repair was triggered / succeeded
+            "repair_triggered": 0,
+            "repair_succeeded": 0,
         }
 
         if not self.enabled:
@@ -232,6 +235,14 @@ class EvolutionTracer:
                 if delta < self.stats["worst_decline"][metric]:
                     self.stats["worst_decline"][metric] = delta
 
+        # Track repair statistics from child program metadata
+        child_meta = trace.metadata or {}
+        repair_history = child_meta.get("repair_history")
+        if repair_history is not None:
+            self.stats["repair_triggered"] += 1
+            if any(entry.get("succeeded") for entry in repair_history):
+                self.stats["repair_succeeded"] += 1
+
     def flush(self):
         """Write buffered traces to file"""
         if not self.enabled or not self.buffer:
@@ -259,12 +270,18 @@ class EvolutionTracer:
 
     def get_statistics(self) -> Dict[str, Any]:
         """Get current tracing statistics"""
+        total = self.stats["total_traces"]
+        triggered = self.stats["repair_triggered"]
         return {
             **self.stats,
             "improvement_rate": (
-                self.stats["improvement_count"] / self.stats["total_traces"]
-                if self.stats["total_traces"] > 0
-                else 0
+                self.stats["improvement_count"] / total if total > 0 else 0
+            ),
+            # Fraction of all iterations where repair was triggered
+            "repair_trigger_rate": triggered / total if total > 0 else 0,
+            # Fraction of repair attempts that succeeded
+            "repair_success_rate": (
+                self.stats["repair_succeeded"] / triggered if triggered > 0 else 0
             ),
         }
 
@@ -302,6 +319,13 @@ class EvolutionTracer:
         stats = self.get_statistics()
         logger.info(f"Evolution tracing complete. Total traces: {stats['total_traces']}")
         logger.info(f"Improvement rate: {stats['improvement_rate']:.2%}")
+
+        if stats["repair_triggered"] > 0:
+            logger.info(
+                f"Repair: triggered={stats['repair_triggered']}, "
+                f"succeeded={stats['repair_succeeded']}, "
+                f"success_rate={stats['repair_success_rate']:.2%}"
+            )
 
         if stats["best_improvement"]:
             logger.info(f"Best improvements: {stats['best_improvement']}")

--- a/openevolve/iteration.py
+++ b/openevolve/iteration.py
@@ -168,6 +168,21 @@ async def run_iteration_with_shared_db(
         # Handle artifacts if they exist
         artifacts = evaluator.get_pending_artifacts(child_id)
 
+        # If the evaluator performed an LLM repair, use the repaired code as
+        # the canonical source for the database entry and demote the original
+        # broken LLM output to metadata["original_llm_code"].
+        repaired_code = evaluator.get_pending_repair(child_id)
+        repair_metadata: dict = {}
+        if repaired_code is not None:
+            repair_metadata["original_llm_code"] = child_code
+            repair_metadata["repair_history"] = (
+                (artifacts or {}).pop("repair_history", [])
+            )
+            child_code = repaired_code
+            logger.info(
+                f"Iteration {iteration}: using LLM-repaired code for program {child_id}"
+            )
+
         # Set template_key of Prompts
         template_key = "full_rewrite_user" if not config.diff_based_evolution else "diff_user"
 
@@ -184,6 +199,7 @@ async def run_iteration_with_shared_db(
             metadata={
                 "changes": changes_summary,
                 "parent_metrics": parent.metrics,
+                **repair_metadata,
             },
             prompts=(
                 {

--- a/openevolve/process_parallel.py
+++ b/openevolve/process_parallel.py
@@ -294,6 +294,17 @@ def _run_iteration_worker(
         # Get artifacts
         artifacts = _worker_evaluator.get_pending_artifacts(child_id)
 
+        # Apply LLM repair if the evaluator performed one (mirrors iteration.py)
+        repaired_code = _worker_evaluator.get_pending_repair(child_id)
+        repair_metadata: dict = {}
+        if repaired_code is not None:
+            repair_metadata["original_llm_code"] = child_code
+            repair_metadata["repair_history"] = (artifacts or {}).pop("repair_history", [])
+            child_code = repaired_code
+            logger.info(
+                f"Worker iteration {iteration}: using LLM-repaired code for program {child_id}"
+            )
+
         # Create child program
         child_program = Program(
             id=child_id,
@@ -308,6 +319,7 @@ def _run_iteration_worker(
                 "changes": changes_summary,
                 "parent_metrics": parent.metrics,
                 "island": parent_island,
+                **repair_metadata,
             },
         )
 
@@ -593,8 +605,11 @@ class ProcessParallelController:
                                 artifacts=result.artifacts,
                                 island_id=island_id,
                                 metadata={
+                                    **{
+                                        k: v for k, v in child_program.metadata.items()
+                                        if k not in ("parent_metrics", "island")
+                                    },
                                     "iteration_time": result.iteration_time,
-                                    "changes": child_program.metadata.get("changes", ""),
                                 },
                             )
 

--- a/openevolve/process_parallel.py
+++ b/openevolve/process_parallel.py
@@ -64,11 +64,13 @@ def _worker_init(config_dict: dict, evaluation_file: str, parent_env: dict = Non
     # Reconstruct model objects
     models = [LLMModelConfig(**m) for m in config_dict["llm"]["models"]]
     evaluator_models = [LLMModelConfig(**m) for m in config_dict["llm"]["evaluator_models"]]
+    repair_models = [LLMModelConfig(**m) for m in config_dict["llm"].get("repair_models", [])]
 
     # Create LLM config with models
     llm_dict = config_dict["llm"].copy()
     llm_dict["models"] = models
     llm_dict["evaluator_models"] = evaluator_models
+    llm_dict["repair_models"] = repair_models
     llm_config = LLMConfig(**llm_dict)
 
     # Create other configs
@@ -118,6 +120,7 @@ def _lazy_init_worker_components():
 
         # Create evaluator-specific components
         evaluator_llm = LLMEnsemble(_worker_config.llm.evaluator_models)
+        repair_llm = LLMEnsemble(_worker_config.llm.repair_models)
         evaluator_prompt = PromptSampler(_worker_config.prompt)
         evaluator_prompt.set_templates("evaluator_system_message")
 
@@ -128,6 +131,7 @@ def _lazy_init_worker_components():
             evaluator_prompt,
             database=None,  # No shared database in worker
             suffix=getattr(_worker_config, "file_suffix", ".py"),
+            repair_llm_ensemble=repair_llm,
         )
 
 
@@ -382,6 +386,7 @@ class ProcessParallelController:
             "llm": {
                 "models": [asdict(m) for m in config.llm.models],
                 "evaluator_models": [asdict(m) for m in config.llm.evaluator_models],
+                "repair_models": [asdict(m) for m in config.llm.repair_models],
                 "api_base": config.llm.api_base,
                 "api_key": config.llm.api_key,
                 "temperature": config.llm.temperature,

--- a/openevolve/prompts/defaults/repair_diff_user.txt
+++ b/openevolve/prompts/defaults/repair_diff_user.txt
@@ -1,0 +1,27 @@
+The following {language} program failed to evaluate due to the error below.
+Repair the program using minimal SEARCH/REPLACE diffs.
+Preserve all structure, class names, plugin keys, and invariants that are unrelated to the error.
+
+# Error
+
+{error_message}
+
+# Additional context
+
+{repair_context}
+
+# Broken Program
+
+```{language}
+{broken_code}
+```
+
+Use the exact SEARCH/REPLACE diff format shown below.
+Each SEARCH block must match the broken program exactly (including whitespace).
+Multiple diff blocks are allowed.
+
+<<<<<<< SEARCH
+# exact lines to replace
+=======
+# corrected replacement
+>>>>>>> REPLACE

--- a/openevolve/prompts/defaults/repair_full_rewrite_user.txt
+++ b/openevolve/prompts/defaults/repair_full_rewrite_user.txt
@@ -1,0 +1,24 @@
+The following {language} program failed to evaluate due to the error below.
+Repair the program so that all errors are resolved.
+Preserve all structure, class names, plugin keys, and invariants that are unrelated to the error.
+
+# Error
+
+{error_message}
+
+# Additional context
+
+{repair_context}
+
+# Broken Program
+
+```{language}
+{broken_code}
+```
+
+Output ONLY the complete corrected program inside a single code fence.
+Do not include any commentary, explanation, or text outside the code fence.
+
+```{language}
+# corrected program here
+```

--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -313,7 +313,12 @@ export function showSidebarContent(d, fromHover = false) {
     if (parentNodeForDiff && parentNodeForDiff.code && parentNodeForDiff.code.trim() !== '') {
         tabNames.push('Diff');
     }
- 
+
+    // Add a Repairs tab when LLM repair was performed on this program
+    if (d.metadata && d.metadata.repair_history && d.metadata.repair_history.length > 0) {
+        tabNames.push('Repairs');
+    }
+
         let activeTab = lastSidebarTab && tabNames.includes(lastSidebarTab) ? lastSidebarTab : tabNames[0];
  
         // Helper to render tab content
@@ -449,6 +454,33 @@ export function showSidebarContent(d, fromHover = false) {
                  const parentCode = parentNode ? parentNode.code || '' : '';
                  const curCode = d.code || '';
                  return renderCodeDiff(parentCode, curCode);
+             }
+             if (tabName === 'Repairs') {
+                 const originalCode = (d.metadata && d.metadata.original_llm_code) || '';
+                 const repairedCode = d.code || '';
+                 const history = (d.metadata && d.metadata.repair_history) || [];
+                 // Attempt table
+                 const tableRows = history.map(function(entry) {
+                     const bg = entry.succeeded ? '#f2fff2' : '#fff0f0';
+                     const result = entry.succeeded ? '✓ succeeded' : '✗ failed';
+                     const errText = escapeHtml(entry.error || entry.repair_error || '');
+                     return '<tr style="background:' + bg + ';">' +
+                         '<td style="border:1px solid #ccc;padding:3px 7px;text-align:center;">' + (entry.attempt || '') + '</td>' +
+                         '<td style="border:1px solid #ccc;padding:3px 7px;">' + result + '</td>' +
+                         '<td style="border:1px solid #ccc;padding:3px 7px;font-size:0.85em;white-space:pre-wrap;word-break:break-all;">' + errText + '</td>' +
+                         '</tr>';
+                 }).join('');
+                 const tableHtml = '<table style="border-collapse:collapse;width:100%;margin-bottom:0.7em;font-size:0.91em;">' +
+                     '<thead><tr style="background:#e8e8e8;">' +
+                     '<th style="border:1px solid #ccc;padding:3px 7px;">Attempt</th>' +
+                     '<th style="border:1px solid #ccc;padding:3px 7px;">Result</th>' +
+                     '<th style="border:1px solid #ccc;padding:3px 7px;">Error</th>' +
+                     '</tr></thead><tbody>' + tableRows + '</tbody></table>';
+                 const diffHtml = originalCode
+                     ? '<div style="margin-bottom:0.3em;color:#666;font-size:0.9em;">Diff: original LLM output → repaired code</div>' +
+                       renderCodeDiff(originalCode, repairedCode)
+                     : '<div style="color:#888;font-size:0.9em;">(Original code not recorded)</div>';
+                 return tableHtml + diffHtml;
              }
              return '';
          }

--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -461,20 +461,21 @@ export function showSidebarContent(d, fromHover = false) {
                  const history = (d.metadata && d.metadata.repair_history) || [];
                  // Attempt table
                  const tableRows = history.map(function(entry) {
-                     const bg = entry.succeeded ? '#f2fff2' : '#fff0f0';
-                     const result = entry.succeeded ? '✓ succeeded' : '✗ failed';
-                     const errText = escapeHtml(entry.error || entry.repair_error || '');
-                     return '<tr style="background:' + bg + ';">' +
-                         '<td style="border:1px solid #ccc;padding:3px 7px;text-align:center;">' + (entry.attempt || '') + '</td>' +
-                         '<td style="border:1px solid #ccc;padding:3px 7px;">' + result + '</td>' +
-                         '<td style="border:1px solid #ccc;padding:3px 7px;font-size:0.85em;white-space:pre-wrap;word-break:break-all;">' + errText + '</td>' +
+                     const badge = entry.succeeded
+                         ? '<span style="display:inline-block;padding:1px 7px;border-radius:3px;background:#1a7f3c;color:#fff;font-weight:600;font-size:0.88em;">✓ ok</span>'
+                         : '<span style="display:inline-block;padding:1px 7px;border-radius:3px;background:#b91c1c;color:#fff;font-weight:600;font-size:0.88em;">✗ fail</span>';
+                     const errText = escapeHtml(entry.error || entry.repair_error || '—');
+                     return '<tr style="border-bottom:1px solid #ddd;">' +
+                         '<td style="padding:5px 10px;text-align:center;font-weight:600;color:#444;">' + (entry.attempt || '') + '</td>' +
+                         '<td style="padding:5px 10px;">' + badge + '</td>' +
+                         '<td style="padding:5px 10px;font-size:0.83em;white-space:pre-wrap;word-break:break-all;color:#333;font-family:monospace;">' + errText + '</td>' +
                          '</tr>';
                  }).join('');
-                 const tableHtml = '<table style="border-collapse:collapse;width:100%;margin-bottom:0.7em;font-size:0.91em;">' +
-                     '<thead><tr style="background:#e8e8e8;">' +
-                     '<th style="border:1px solid #ccc;padding:3px 7px;">Attempt</th>' +
-                     '<th style="border:1px solid #ccc;padding:3px 7px;">Result</th>' +
-                     '<th style="border:1px solid #ccc;padding:3px 7px;">Error</th>' +
+                 const tableHtml = '<table style="border-collapse:collapse;width:100%;margin-bottom:0.9em;font-size:0.91em;background:#fff;border:1px solid #ddd;border-radius:4px;overflow:hidden;">' +
+                     '<thead><tr style="background:#2d3748;color:#fff;">' +
+                     '<th style="padding:5px 10px;font-weight:600;text-align:center;width:70px;">#</th>' +
+                     '<th style="padding:5px 10px;font-weight:600;width:90px;">Status</th>' +
+                     '<th style="padding:5px 10px;font-weight:600;">Compiler output / notes</th>' +
                      '</tr></thead><tbody>' + tableRows + '</tbody></table>';
                  const diffHtml = originalCode
                      ? '<div style="margin-bottom:0.3em;color:#666;font-size:0.9em;">Diff: original LLM output → repaired code</div>' +

--- a/scripts/templates/program_page.html
+++ b/scripts/templates/program_page.html
@@ -46,23 +46,27 @@
     <pre>{{ program_data.metadata.original_llm_code }}</pre>
     {% endif %}
     <h3>Repair attempts:</h3>
-    <table style="border-collapse:collapse;width:100%;">
+    <table style="border-collapse:collapse;width:100%;border:1px solid #ddd;border-radius:4px;overflow:hidden;">
       <thead>
-        <tr style="background:#e8e8e8;">
-          <th style="border:1px solid #ccc;padding:6px 10px;">Attempt</th>
-          <th style="border:1px solid #ccc;padding:6px 10px;">Result</th>
-          <th style="border:1px solid #ccc;padding:6px 10px;">Error</th>
+        <tr style="background:#2d3748;color:#fff;">
+          <th style="padding:6px 10px;font-weight:600;text-align:center;width:70px;">#</th>
+          <th style="padding:6px 10px;font-weight:600;width:100px;">Status</th>
+          <th style="padding:6px 10px;font-weight:600;">Compiler output / notes</th>
         </tr>
       </thead>
       <tbody>
         {% for entry in program_data.metadata.repair_history %}
-        <tr style="{{ 'background:#f2fff2;' if entry.succeeded else 'background:#fff0f0;' }}">
-          <td style="border:1px solid #ccc;padding:6px 10px;text-align:center;">{{ entry.attempt }}</td>
-          <td style="border:1px solid #ccc;padding:6px 10px;text-align:center;">
-            {{ '✓ succeeded' if entry.succeeded else '✗ failed' }}
+        <tr style="border-bottom:1px solid #ddd;">
+          <td style="padding:6px 10px;text-align:center;font-weight:600;color:#444;">{{ entry.attempt }}</td>
+          <td style="padding:6px 10px;">
+            {% if entry.succeeded %}
+            <span style="display:inline-block;padding:1px 8px;border-radius:3px;background:#1a7f3c;color:#fff;font-weight:600;font-size:0.88em;">✓ ok</span>
+            {% else %}
+            <span style="display:inline-block;padding:1px 8px;border-radius:3px;background:#b91c1c;color:#fff;font-weight:600;font-size:0.88em;">✗ fail</span>
+            {% endif %}
           </td>
-          <td style="border:1px solid #ccc;padding:6px 10px;">
-            <pre style="margin:0;">{{ entry.error or entry.repair_error or '' }}</pre>
+          <td style="padding:6px 10px;">
+            <pre style="margin:0;font-size:0.85em;color:#333;">{{ entry.error or entry.repair_error or '—' }}</pre>
           </td>
         </tr>
         {% endfor %}

--- a/scripts/templates/program_page.html
+++ b/scripts/templates/program_page.html
@@ -36,6 +36,39 @@
         </ul>
     <h2>Code:</h2>
     <pre>{{ program_data.code }}</pre>
+    {% if program_data.metadata and program_data.metadata.repair_history %}
+    <h2>Repairs:</h2>
+    <p>This program was repaired by the LLM before evaluation.
+       The repaired source is shown above.
+       The original broken LLM output and repair attempts are shown below.</p>
+    {% if program_data.metadata.original_llm_code %}
+    <h3>Original LLM-generated code (before repair):</h3>
+    <pre>{{ program_data.metadata.original_llm_code }}</pre>
+    {% endif %}
+    <h3>Repair attempts:</h3>
+    <table style="border-collapse:collapse;width:100%;">
+      <thead>
+        <tr style="background:#e8e8e8;">
+          <th style="border:1px solid #ccc;padding:6px 10px;">Attempt</th>
+          <th style="border:1px solid #ccc;padding:6px 10px;">Result</th>
+          <th style="border:1px solid #ccc;padding:6px 10px;">Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in program_data.metadata.repair_history %}
+        <tr style="{{ 'background:#f2fff2;' if entry.succeeded else 'background:#fff0f0;' }}">
+          <td style="border:1px solid #ccc;padding:6px 10px;text-align:center;">{{ entry.attempt }}</td>
+          <td style="border:1px solid #ccc;padding:6px 10px;text-align:center;">
+            {{ '✓ succeeded' if entry.succeeded else '✗ failed' }}
+          </td>
+          <td style="border:1px solid #ccc;padding:6px 10px;">
+            <pre style="margin:0;">{{ entry.error or entry.repair_error or '' }}</pre>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
     <h2>Prompts:</h2>
     <ul>
         {#-- recursive “display” macro --#}

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,505 @@
+"""
+Tests for the LLM-based code repair feature.
+
+Covers:
+  - EvaluatorRepairRequest exception construction
+  - Evaluator._pending_repairs / get_pending_repair()
+  - evaluate_program() behaviour when repair is disabled / enabled
+  - _attempt_repair() success and failure paths
+  - repair_history propagation into pending_artifacts
+  - EvolutionTracer repair statistics
+  - iteration.py repair metadata interception logic
+"""
+
+import asyncio
+import os
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from openevolve.config import EvaluatorConfig
+from openevolve.evaluation_result import EvaluationResult, EvaluatorRepairRequest
+from openevolve.evaluator import Evaluator
+from openevolve.evolution_trace import EvolutionTrace, EvolutionTracer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_eval_file(body: str) -> str:
+    """Write a Python evaluator snippet to a temp file and return its path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
+    # Injecting the openevolve path so the eval file can import EvaluatorRepairRequest
+    f.write("import sys, os\n")
+    f.write("sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))\n")
+    f.write(body)
+    f.close()
+    return f.name
+
+
+def _make_evaluator(config: EvaluatorConfig, eval_file: str, **kwargs) -> Evaluator:
+    """Create an Evaluator without LLM ensemble or prompt sampler (unless supplied)."""
+    return Evaluator(
+        config=config,
+        evaluation_file=eval_file,
+        llm_ensemble=kwargs.get("llm_ensemble"),
+        prompt_sampler=kwargs.get("prompt_sampler"),
+        suffix=".py",
+    )
+
+
+# ---------------------------------------------------------------------------
+# EvaluatorRepairRequest
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorRepairRequest(unittest.TestCase):
+    """Basic construction and attribute tests."""
+
+    def test_message_is_str(self):
+        req = EvaluatorRepairRequest("compile error", "int x = ]")
+        self.assertEqual(str(req), "compile error")
+
+    def test_all_fields_explicit(self):
+        req = EvaluatorRepairRequest(
+            message="bad code",
+            broken_code="int x = ]",
+            repair_context="full compiler output",
+            language="cpp",
+        )
+        self.assertEqual(req.broken_code, "int x = ]")
+        self.assertEqual(req.repair_context, "full compiler output")
+        self.assertEqual(req.language, "cpp")
+
+    def test_repair_context_defaults_to_message(self):
+        req = EvaluatorRepairRequest("error msg", "broken")
+        self.assertEqual(req.repair_context, "error msg")
+
+    def test_language_defaults_to_python(self):
+        req = EvaluatorRepairRequest("err", "code")
+        self.assertEqual(req.language, "python")
+
+    def test_is_exception(self):
+        req = EvaluatorRepairRequest("err", "code")
+        self.assertIsInstance(req, Exception)
+
+
+# ---------------------------------------------------------------------------
+# get_pending_repair
+# ---------------------------------------------------------------------------
+
+class TestGetPendingRepair(unittest.TestCase):
+    """Tests for the _pending_repairs side-channel."""
+
+    def setUp(self):
+        eval_src = "def evaluate(path): return {'score': 1.0}\n"
+        self.eval_file = _make_eval_file(eval_src)
+        self.evaluator = _make_evaluator(EvaluatorConfig(), self.eval_file)
+
+    def tearDown(self):
+        os.unlink(self.eval_file)
+
+    def test_returns_none_when_absent(self):
+        self.assertIsNone(self.evaluator.get_pending_repair("no-such-id"))
+
+    def test_returns_code_and_clears(self):
+        self.evaluator._pending_repairs["prog-1"] = "repaired source"
+        result = self.evaluator.get_pending_repair("prog-1")
+        self.assertEqual(result, "repaired source")
+        # Second call must return None (one-shot)
+        self.assertIsNone(self.evaluator.get_pending_repair("prog-1"))
+
+    def test_independent_ids(self):
+        self.evaluator._pending_repairs["a"] = "code_a"
+        self.evaluator._pending_repairs["b"] = "code_b"
+        self.assertEqual(self.evaluator.get_pending_repair("a"), "code_a")
+        self.assertEqual(self.evaluator.get_pending_repair("b"), "code_b")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_program with repair
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorRepairFlow(unittest.TestCase):
+    """
+    Tests evaluate_program() when the evaluation function raises
+    EvaluatorRepairRequest. Uses patch.object to control _direct_evaluate
+    and _repair_code so no real LLM calls or file compilation occurs.
+    """
+
+    def setUp(self):
+        eval_src = "def evaluate(path): return {'combined_score': 0.9}\n"
+        self.eval_file = _make_eval_file(eval_src)
+
+    def tearDown(self):
+        os.unlink(self.eval_file)
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    # ------------------------------------------------------------------
+    # repair disabled
+    # ------------------------------------------------------------------
+
+    def test_repair_disabled_returns_zero_score(self):
+        """When repair_on_failure=False, a repair request yields score 0."""
+        config = EvaluatorConfig(repair_on_failure=False, cascade_evaluation=False)
+        ev = _make_evaluator(config, self.eval_file)
+
+        repair_req = EvaluatorRepairRequest("compile error", "broken cpp", language="cpp")
+        success_result = EvaluationResult(metrics={"combined_score": 0.9})
+
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(
+            side_effect=[repair_req, success_result]
+        )):
+            metrics = self._run(ev.evaluate_program("broken code", "prog-1"))
+
+        self.assertEqual(metrics.get("combined_score"), 0.0)
+        self.assertIsNone(ev.get_pending_repair("prog-1"))
+
+    def test_repair_disabled_stores_compile_error_artifact(self):
+        config = EvaluatorConfig(repair_on_failure=False, cascade_evaluation=False)
+        ev = _make_evaluator(config, self.eval_file)
+
+        repair_req = EvaluatorRepairRequest("compile error", "bad code", language="cpp")
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(side_effect=repair_req)):
+            self._run(ev.evaluate_program("bad code", "prog-2"))
+
+        artifacts = ev.get_pending_artifacts("prog-2")
+        self.assertIsNotNone(artifacts)
+        self.assertIn("compile_error", artifacts)
+
+    # ------------------------------------------------------------------
+    # repair enabled, succeeds
+    # ------------------------------------------------------------------
+
+    def test_repair_succeeds_first_attempt(self):
+        """Repair succeeds on the first LLM attempt → real metrics returned."""
+        config = EvaluatorConfig(
+            repair_on_failure=True,
+            max_repair_attempts=2,
+            repair_diff_based=False,
+            cascade_evaluation=False,
+        )
+        mock_llm = MagicMock()
+        ev = _make_evaluator(config, self.eval_file, llm_ensemble=mock_llm)
+
+        repair_req = EvaluatorRepairRequest("compile error", "broken", language="cpp")
+        success = EvaluationResult(metrics={"combined_score": 0.85})
+
+        # First _direct_evaluate raises repair request; second returns success.
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(
+            side_effect=[repair_req, success]
+        )):
+            with patch.object(ev, "_repair_code", new=AsyncMock(return_value="fixed code")):
+                metrics = self._run(ev.evaluate_program("broken", "prog-3"))
+
+        self.assertAlmostEqual(metrics.get("combined_score"), 0.85)
+        self.assertEqual(ev.get_pending_repair("prog-3"), "fixed code")
+
+    def test_repair_stores_history_in_artifacts(self):
+        config = EvaluatorConfig(
+            repair_on_failure=True,
+            max_repair_attempts=2,
+            cascade_evaluation=False,
+        )
+        mock_llm = MagicMock()
+        ev = _make_evaluator(config, self.eval_file, llm_ensemble=mock_llm)
+
+        repair_req = EvaluatorRepairRequest("oops", "broken", language="cpp")
+        success = EvaluationResult(metrics={"combined_score": 0.7})
+
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(
+            side_effect=[repair_req, success]
+        )):
+            with patch.object(ev, "_repair_code", new=AsyncMock(return_value="fixed")):
+                self._run(ev.evaluate_program("broken", "prog-4"))
+
+        artifacts = ev.get_pending_artifacts("prog-4")
+        self.assertIsNotNone(artifacts)
+        history = artifacts.get("repair_history", [])
+        self.assertEqual(len(history), 1)
+        self.assertTrue(history[0]["succeeded"])
+
+    def test_repair_succeeds_second_attempt(self):
+        """First repair attempt also fails; second succeeds."""
+        config = EvaluatorConfig(
+            repair_on_failure=True,
+            max_repair_attempts=2,
+            cascade_evaluation=False,
+        )
+        mock_llm = MagicMock()
+        ev = _make_evaluator(config, self.eval_file, llm_ensemble=mock_llm)
+
+        repair_req1 = EvaluatorRepairRequest("err1", "broken1", language="cpp")
+        repair_req2 = EvaluatorRepairRequest("err2", "broken2", language="cpp")
+        success = EvaluationResult(metrics={"combined_score": 0.6})
+
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(
+            side_effect=[repair_req1, repair_req2, success]
+        )):
+            # _repair_code returns a (different) fix each call
+            with patch.object(ev, "_repair_code", new=AsyncMock(
+                side_effect=["fix1", "fix2"]
+            )):
+                metrics = self._run(ev.evaluate_program("broken1", "prog-5"))
+
+        self.assertAlmostEqual(metrics.get("combined_score"), 0.6)
+        self.assertEqual(ev.get_pending_repair("prog-5"), "fix2")
+
+        artifacts = ev.get_pending_artifacts("prog-5")
+        history = artifacts.get("repair_history", [])
+        self.assertEqual(len(history), 2)
+        self.assertFalse(history[0]["succeeded"])
+        self.assertTrue(history[1]["succeeded"])
+
+    # ------------------------------------------------------------------
+    # repair enabled, all attempts fail
+    # ------------------------------------------------------------------
+
+    def test_repair_all_attempts_fail_returns_zero(self):
+        config = EvaluatorConfig(
+            repair_on_failure=True,
+            max_repair_attempts=2,
+            cascade_evaluation=False,
+        )
+        mock_llm = MagicMock()
+        ev = _make_evaluator(config, self.eval_file, llm_ensemble=mock_llm)
+
+        repair_req = EvaluatorRepairRequest("err", "broken", language="cpp")
+
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(side_effect=repair_req)):
+            # _repair_code always returns "fixed" but re-evaluation always fails
+            with patch.object(ev, "_repair_code", new=AsyncMock(return_value="fixed")):
+                metrics = self._run(ev.evaluate_program("broken", "prog-6"))
+
+        # All attempts failed → score 0
+        self.assertEqual(metrics.get("combined_score"), 0.0)
+        # No pending repair stored
+        self.assertIsNone(ev.get_pending_repair("prog-6"))
+        # repair_failed flag set in artifacts
+        artifacts = ev.get_pending_artifacts("prog-6")
+        self.assertTrue(artifacts.get("repair_failed"))
+
+    def test_repair_code_returns_none_aborts(self):
+        """If _repair_code can't parse a fix, repair aborts cleanly."""
+        config = EvaluatorConfig(
+            repair_on_failure=True,
+            max_repair_attempts=3,
+            cascade_evaluation=False,
+        )
+        mock_llm = MagicMock()
+        ev = _make_evaluator(config, self.eval_file, llm_ensemble=mock_llm)
+
+        repair_req = EvaluatorRepairRequest("err", "broken", language="cpp")
+        with patch.object(ev, "_direct_evaluate", new=AsyncMock(side_effect=repair_req)):
+            with patch.object(ev, "_repair_code", new=AsyncMock(return_value=None)):
+                metrics = self._run(ev.evaluate_program("broken", "prog-7"))
+
+        self.assertEqual(metrics.get("combined_score"), 0.0)
+        self.assertIsNone(ev.get_pending_repair("prog-7"))
+
+
+# ---------------------------------------------------------------------------
+# _repair_code template safety (brace escaping)
+# ---------------------------------------------------------------------------
+
+class TestRepairCodeTemplateSafety(unittest.TestCase):
+    """
+    _repair_code must not raise KeyError when broken_code contains C++ braces.
+    We test the safe substitution logic by supplying a minimal mock template
+    directly in the template manager.
+    """
+
+    def setUp(self):
+        eval_src = "def evaluate(path): return {'score': 1.0}\n"
+        self.eval_file = _make_eval_file(eval_src)
+
+    def tearDown(self):
+        os.unlink(self.eval_file)
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_cpp_braces_in_broken_code_do_not_crash(self):
+        """Code like 'namespace foo { {} }' must not crash the template formatter."""
+        config = EvaluatorConfig(repair_on_failure=True, max_repair_attempts=1)
+        mock_llm = AsyncMock()
+        # Return a valid code-fenced response so parse_full_rewrite succeeds
+        mock_llm.generate_with_context = AsyncMock(
+            return_value="```cpp\nint main(){}\n```"
+        )
+
+        def _get_template(name):
+            if name == "repair_full_rewrite_user":
+                return "fix: {broken_code}"
+            if name == "system_message":
+                return "You are an expert programmer."
+            raise ValueError(f"Template '{name}' not found")
+
+        mock_sampler = MagicMock()
+        mock_sampler.template_manager.get_template.side_effect = _get_template
+
+        ev = _make_evaluator(
+            config, self.eval_file,
+            llm_ensemble=mock_llm,
+            prompt_sampler=mock_sampler,
+        )
+
+        # C++ code with many braces
+        cpp_with_braces = "namespace ns { struct S { void f(){} }; }"
+        result = self._run(ev._repair_code(
+            broken_code=cpp_with_braces,
+            error_message="compile error",
+            repair_context="full output",
+            language="cpp",
+        ))
+        # Should return the parsed code, not crash
+        self.assertEqual(result, "int main(){}")
+
+
+# ---------------------------------------------------------------------------
+# EvolutionTracer repair stats
+# ---------------------------------------------------------------------------
+
+class TestEvolutionTracerRepairStats(unittest.TestCase):
+    """Tests for repair_triggered / repair_succeeded counters."""
+
+    def _make_tracer(self) -> EvolutionTracer:
+        return EvolutionTracer(enabled=False)
+
+    def _make_trace(self, repair_history=None) -> EvolutionTrace:
+        meta = {}
+        if repair_history is not None:
+            meta["repair_history"] = repair_history
+        return EvolutionTrace(
+            iteration=1,
+            timestamp=0.0,
+            parent_id="p1",
+            child_id="c1",
+            parent_metrics={"combined_score": 0.5},
+            child_metrics={"combined_score": 0.6},
+            metadata=meta,
+        )
+
+    def test_no_repair_no_stats_change(self):
+        tracer = self._make_tracer()
+        trace = self._make_trace(repair_history=None)
+        tracer._update_stats(trace)
+        self.assertEqual(tracer.stats["repair_triggered"], 0)
+        self.assertEqual(tracer.stats["repair_succeeded"], 0)
+
+    def test_repair_triggered_incremented(self):
+        tracer = self._make_tracer()
+        trace = self._make_trace(repair_history=[{"attempt": 1, "error": "err", "succeeded": False}])
+        tracer._update_stats(trace)
+        self.assertEqual(tracer.stats["repair_triggered"], 1)
+        self.assertEqual(tracer.stats["repair_succeeded"], 0)
+
+    def test_repair_triggered_and_succeeded(self):
+        tracer = self._make_tracer()
+        trace = self._make_trace(repair_history=[
+            {"attempt": 1, "error": "err1", "succeeded": False},
+            {"attempt": 2, "error": None, "succeeded": True},
+        ])
+        tracer._update_stats(trace)
+        self.assertEqual(tracer.stats["repair_triggered"], 1)
+        self.assertEqual(tracer.stats["repair_succeeded"], 1)
+
+    def test_get_statistics_includes_rates(self):
+        tracer = self._make_tracer()
+        # Simulate 4 traces: 2 triggered repair, 1 succeeded
+        for _ in range(2):
+            tracer._update_stats(self._make_trace())  # no repair
+        tracer._update_stats(self._make_trace([{"attempt": 1, "error": "e", "succeeded": True}]))
+        tracer._update_stats(self._make_trace([{"attempt": 1, "error": "e", "succeeded": False}]))
+
+        stats = tracer.get_statistics()
+        self.assertEqual(stats["repair_triggered"], 2)
+        self.assertEqual(stats["repair_succeeded"], 1)
+        self.assertAlmostEqual(stats["repair_trigger_rate"], 0.5)
+        self.assertAlmostEqual(stats["repair_success_rate"], 0.5)
+
+    def test_repair_rates_zero_when_none_triggered(self):
+        tracer = self._make_tracer()
+        tracer._update_stats(self._make_trace())
+        stats = tracer.get_statistics()
+        self.assertEqual(stats["repair_trigger_rate"], 0)
+        self.assertEqual(stats["repair_success_rate"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Repair metadata interception logic (mirrors iteration.py)
+# ---------------------------------------------------------------------------
+
+class TestRepairMetadataInterception(unittest.TestCase):
+    """
+    Tests the logic that iteration.py and process_parallel.py use to
+    intercept repaired code from the evaluator side-channel.
+    """
+
+    def _simulate_interception(self, evaluator, child_id, original_code):
+        """Replicate the logic in iteration.py after evaluate_program returns."""
+        artifacts = evaluator.get_pending_artifacts(child_id)
+        repaired_code = evaluator.get_pending_repair(child_id)
+        repair_metadata = {}
+        if repaired_code is not None:
+            repair_metadata["original_llm_code"] = original_code
+            repair_metadata["repair_history"] = (artifacts or {}).pop("repair_history", [])
+            child_code = repaired_code
+        else:
+            child_code = original_code
+        return child_code, repair_metadata, artifacts
+
+    def setUp(self):
+        eval_src = "def evaluate(path): return {'score': 1.0}\n"
+        self.eval_file = _make_eval_file(eval_src)
+        self.evaluator = _make_evaluator(EvaluatorConfig(), self.eval_file)
+
+    def tearDown(self):
+        os.unlink(self.eval_file)
+
+    def test_no_repair_child_code_unchanged(self):
+        original = "original code"
+        child_code, repair_meta, _ = self._simulate_interception(
+            self.evaluator, "prog-x", original
+        )
+        self.assertEqual(child_code, original)
+        self.assertEqual(repair_meta, {})
+
+    def test_repair_child_code_replaced(self):
+        original = "broken code"
+        repaired = "fixed code"
+        history = [{"attempt": 1, "error": None, "succeeded": True}]
+
+        self.evaluator._pending_repairs["prog-y"] = repaired
+        self.evaluator._pending_artifacts["prog-y"] = {"repair_history": history}
+
+        child_code, repair_meta, artifacts = self._simulate_interception(
+            self.evaluator, "prog-y", original
+        )
+
+        self.assertEqual(child_code, repaired)
+        self.assertEqual(repair_meta["original_llm_code"], original)
+        self.assertEqual(repair_meta["repair_history"], history)
+        # repair_history should have been popped from artifacts
+        self.assertNotIn("repair_history", (artifacts or {}))
+
+    def test_repair_history_not_in_llm_artifacts_after_interception(self):
+        """repair_history must be moved to metadata, not remain in prompt artifacts."""
+        self.evaluator._pending_repairs["prog-z"] = "fixed"
+        self.evaluator._pending_artifacts["prog-z"] = {
+            "repair_history": [{"attempt": 1, "succeeded": True}],
+            "domain_breakdown": "some llm artifact",
+        }
+
+        _, _, remaining_artifacts = self._simulate_interception(
+            self.evaluator, "prog-z", "original"
+        )
+
+        self.assertNotIn("repair_history", remaining_artifacts)
+        self.assertIn("domain_breakdown", remaining_artifacts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When generating complex code (such as C++) or when using a more lightweight LLM, the models will likely cause minor issues, e.g. declaring variables with the wrong type or similar easily-corrected flaws. Currently, OpenEvolve will simply evaluate this flawed program, likely scoring it 0, and add it to the population. This will then (possibly) be used as a parent later, which hopefully would fix the compilation issue.

Instead, it could make sense to attempt to correct the flaws immediately, before evaluating the child and adding it to the population. This PR enables such functionality, through an optional repair sub-agent.

The evaluator can raise an `EvaluatorRepairRequest` (defined in `evaluation_results.py`) which wil be caught and trigger a repair agent, if one is available. This can be done anywhere in the evaluator and allows for passing error messages and similar to the repair agent, along with a default score to assign if the repair itself fails (or is disabled).

After each repair attempt, the evaluator will automatically be called again and the repaired child will be evaluated. This could trigger another repair request if needed, and this cycle can be looped a configurable number of times.

To enable the repair subagent, one configures the new `config.yaml` keys:
```yaml
evaluator:
  repair_on_failure: true
  max_repair_attempts: 2
  repair_diff_based: false  # true for SEARCH/REPLACE diffs, false for full rewrite

llm:
  repair_models:  # optional — falls back to evaluator_models, then models
    - name: "your-repair-model"
      weight: 1.0
```
Setting `max_repair_attempts: 0` or `repair_on_failure: false` (defaults) disables the repair sub-agent. A separate LLM (likely smaller) can be used for the repair process, and new prompts are available (`repair_diff_user.txt` and `repair_full_rewrite_user.txt`) to configure the repair behaviour.

The repair changelogs will be stored and can be visualized in a new tab in the visualizer, if this is enabled. 

Happy to discuss and adapt this implementation to better fit the project. Thanks for the great work!