### PR TITLE
use primary_model instead of model for ollama config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ export OPENAI_API_KEY="your-gemini-api-key"
 # config.yaml
 llm:
   api_base: "http://localhost:11434/v1"  # Ollama
-  model: "codellama:7b"
+  api_key: "ollama"
+  primary_model: "codellama:7b"
 ```
 
 </details>


### PR DESCRIPTION
Previously the ollama example in the readme specified the model with the key "model". This would cause openevolve to find an empty list of models. Changing the key to "primary_model" fixes it.