### PR TITLE
fix: explicitly set stream=False to prevent SSE issues with some providers

### DIFF
--- a/openevolve/llm/openai.py
+++ b/openevolve/llm/openai.py
@@ -157,6 +157,7 @@ class OpenAILLM(LLMInterface):
                 "temperature": kwargs.get("temperature", self.temperature),
                 "top_p": kwargs.get("top_p", self.top_p),
                 "max_tokens": kwargs.get("max_tokens", self.max_tokens),
+                "stream": False,  # Explicitly request non-streaming responses to avoid SSE issues
             }
 
             # Handle reasoning_effort for open source reasoning models.


### PR DESCRIPTION
Fixes #436

## Problem
Some LLM API providers (e.g. kivest/ezif endpoints) default to returning streaming Server-Sent Events (SSE) responses instead of standard JSON. The OpenAI client then receives a raw string that lacks a `.choices` attribute, causing:

```
'str' object has no attribute 'choices'
```

## Solution
Add `"stream": False` explicitly to the non-streaming request params in `openevolve/llm/openai.py`. This makes the non-streaming behaviour explicit and ensures JSON is always returned regardless of provider defaults. This is standard OpenAI API behaviour and is a no-op for providers that already default to non-streaming.

## Testing
- Verified the change applies only to the standard (non-reasoning-model) code path
- The fix is backwards-compatible: providers that already return non-streaming JSON are unaffected