### PR TITLE
fix: use _sample_inspirations in sample_from_island for consistent inspiration selection

### DIFF
--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -447,21 +447,11 @@ class ProgramDatabase:
             parent = self._sample_from_island_weighted(island_id)
             sampling_mode = "weighted"
 
-        # Select inspirations from the same island
+        # Select inspirations from the same island using the same strategy as sample()
         if num_inspirations is None:
             num_inspirations = 5  # Default for backward compatibility
 
-        # Get other programs from the island for inspirations
-        other_programs = [pid for pid in island_programs if pid != parent.id]
-
-        if len(other_programs) < num_inspirations:
-            # Not enough programs in island, use what we have
-            inspiration_ids = other_programs
-        else:
-            # Sample inspirations
-            inspiration_ids = random.sample(other_programs, num_inspirations)
-
-        inspirations = [self.programs[pid] for pid in inspiration_ids if pid in self.programs]
+        inspirations = self._sample_inspirations(parent, n=num_inspirations)
 
         logger.debug(
             f"Sampled parent {parent.id} and {len(inspirations)} inspirations from island {island_id} "


### PR DESCRIPTION
Fixes #437

## Problem
`sample_from_island()` selects inspiration programs using plain `random.sample()` from island program IDs, while `sample()` delegates to the much richer `_sample_inspirations()` method. This inconsistency means that the parallel execution path (`process_parallel.py` → `sample_from_island`) misses:

- Prioritising the island's best program as an inspiration
- Including top-ranked programs from the island (elite selection ratio)
- Selecting programs from nearby MAP-Elites feature cells for diversity

## Solution
Replace the ad-hoc random sampling block in `sample_from_island()` with a call to `_sample_inspirations(parent, n=num_inspirations)`. Because `_sample_inspirations` derives the target island from `parent.metadata["island"]` — and the parent was sampled from the correct island — the method automatically scopes sampling to the right island, maintaining the same island isolation guarantee.

## Testing
- All 370 existing unit tests pass (`python -m unittest discover tests`)
- The change is a pure behavioural alignment: no interface changes, no new parameters